### PR TITLE
ci: remove path filters from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,6 @@ on:
   pull_request:
     branches:
       - "**"
-    paths:
-      - "src/**"
-      - "test/**"
-      - "package.json"
-      - "package-lock.json"
-      - "rollup.config.js"
-      - "tsconfig*.json"
-      - "vitest.*"
-      - "eslint.config.mjs"
-      - ".github/workflows/ci.yml"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
This PR removes the `paths` filter from the CI workflow configuration. The purpose of this change is to ensure that the Continuous Integration pipeline triggers for every pull request, regardless of which files are modified (e.g., documentation, hidden files, or configuration files not previously listed), ensuring consistent validation for all contributions.

## Changes
- Removed the `paths` restriction from the `pull_request` trigger in `.github/workflows/ci.yml`.

## Breaking Changes
- [x] None
- If any, describe migration steps:

## Checklist
- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `npm run lint` `npm run typecheck` `npm run build` `npm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues
Closes #