### PR TITLE
chore: update repository links and metadata to use heripo-lab namespace

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
  blank_issues_enabled: false
  contact_links:
    - name: Security vulnerability
-     url: https://github.com/kimhongyeon/llm-newsletter-kit-core/security/policy
+     url: https://github.com/heripo-lab/llm-newsletter-kit-core/security/policy
      about: Please report security vulnerabilities privately via our Security Policy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ npm test
 ## Fork & Pull Request Workflow
 
 ### 1. Fork the Repository
-Click "Fork" button on GitHub: https://github.com/kimhongyeon/llm-newsletter-kit-core
+Click "Fork" button on GitHub: https://github.com/heripo-lab/llm-newsletter-kit-core
 
 ### 2. Clone Your Fork
 ```bash
@@ -65,7 +65,7 @@ cd llm-newsletter-kit-core
 
 ### 3. Add Upstream Remote
 ```bash
-git remote add upstream https://github.com/kimhongyeon/llm-newsletter-kit-core.git
+git remote add upstream https://github.com/heripo-lab/llm-newsletter-kit-core.git
 git remote -v  # Verify: origin (your fork), upstream (original repo)
 ```
 
@@ -108,7 +108,7 @@ git push origin feat/your-feature-name
 ### 8. Create Pull Request
 1. Go to your fork on GitHub: `https://github.com/YOUR_USERNAME/llm-newsletter-kit-core`
 2. Click "Compare & pull request" button
-3. Base repository: `kimhongyeon/llm-newsletter-kit-core` base: `main`
+3. Base repository: `heripo-lab/llm-newsletter-kit-core` base: `main`
 4. Head repository: `YOUR_USERNAME/llm-newsletter-kit-core` compare: `feat/your-feature-name`
 5. Fill in PR template with description of changes
 6. Submit!

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 > **Automate domain-expert newsletters powered by AI**
 
 [
-  ![CI](https://github.com/kimhongyeon/llm-newsletter-kit-core/actions/workflows/ci.yml/badge.svg)
-](https://github.com/kimhongyeon/llm-newsletter-kit-core/actions/workflows/ci.yml)
+  ![CI](https://github.com/heripo-lab/llm-newsletter-kit-core/actions/workflows/ci.yml/badge.svg)
+](https://github.com/heripo-lab/llm-newsletter-kit-core/actions/workflows/ci.yml)
 [
   ![npm version](https://img.shields.io/npm/v/%40llm-newsletter-kit/core?logo=npm&color=cb0000)
 ](https://www.npmjs.com/package/@llm-newsletter-kit/core)
 ![coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)
-![license](https://img.shields.io/github/license/kimhongyeon/llm-newsletter-kit-core)
+![license](https://img.shields.io/github/license/heripo-lab/llm-newsletter-kit-core)
 ![node](https://img.shields.io/node/v/%40llm-newsletter-kit/core)
 
 Important: [Code of Conduct](./CODE_OF_CONDUCT.md) • [Security Policy](./SECURITY.md) • [Contributing](./CONTRIBUTING.md)
@@ -45,7 +45,7 @@ His design philosophy: **"Logic in code, reasoning in AI, connections in archite
 
 **Quick Links**
 - Research Radar (Live Service): https://heripo.com/research-radar/subscribe
-- Source Code (Usage Example): https://github.com/kimhongyeon/heripo-research-radar
+- Source Code (Usage Example): https://github.com/heripo-lab/heripo-research-radar
 
 ## Why Code-Based?
 
@@ -129,7 +129,7 @@ const newsletterId = await generator.generate();
 - HTML email templates
 - Preview email configuration
 
-👉 **See the reference implementation: https://github.com/kimhongyeon/heripo-research-radar**
+👉 **See the reference implementation: https://github.com/heripo-lab/heripo-research-radar**
 
 ## Public API Overview
 
@@ -199,7 +199,7 @@ For academic papers or research documentation, you may use the following BibTeX 
   author = {Kim, Hongyeon},
   title = {LLM Newsletter Kit: Type-First Extensible Toolkit for Automating LLM-Based Newsletter Creation},
   year = {2025},
-  url = {https://github.com/kimhongyeon/llm-newsletter-kit-core},
+  url = {https://github.com/heripo-lab/llm-newsletter-kit-core},
   note = {Apache License 2.0}
 }
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@
  
  Please do NOT open public GitHub issues for security vulnerabilities.
  
- - Use GitHub Security Advisories to privately report issues: https://github.com/kimhongyeon/llm-newsletter-kit-core/security/advisories/new
+ - Use GitHub Security Advisories to privately report issues: https://github.com/heripo-lab/llm-newsletter-kit-core/security/advisories/new
  - Alternatively, you can reach out via GitHub Discussions if you’re unsure whether a finding is security-related.
  
  Provide as much detail as possible:

--- a/package.json
+++ b/package.json
@@ -75,12 +75,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/kimhongyeon/llm-newsletter-kit-core"
+    "url": "https://github.com/heripo-lab/llm-newsletter-kit-core"
   },
   "bugs": {
-    "url": "https://github.com/kimhongyeon/llm-newsletter-kit-core/issues"
+    "url": "https://github.com/heripo-lab/llm-newsletter-kit-core/issues"
   },
-  "homepage": "https://github.com/kimhongyeon/llm-newsletter-kit-core",
+  "homepage": "https://github.com/heripo-lab/llm-newsletter-kit-core",
   "keywords": [
     "llm",
     "newsletter",


### PR DESCRIPTION
## Summary
The purpose of this PR is to migrate the project's repository links and metadata from the personal namespace (`kimhongyeon`) to the official organization namespace (`heripo-lab`). This ensures all documentation, CI badges, and package metadata point to the correct location.

## Changes
- Updated GitHub repository URLs across all documentation (README, CONTRIBUTING, SECURITY).
- Adjusted issue template configurations to point to the new security policy location.
- Updated `package.json` repository, bugs, and homepage fields to reflect the namespace change.
- Fixed CI badge links and reference implementation URLs in the README.

## Breaking Changes
- [x] None
- If any, describe migration steps: 
  *Note: Users who have cloned the repository locally may need to update their remote URLs using `git remote set-url upstream`.*

## Checklist
- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `npm run lint` `npm run typecheck` `npm run build` `npm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues
Closes #