### PR TITLE
chore: update dependencies and bump Node.js engine to >=24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@acemir/cssom": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "nodejs"
   ],
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
Update all dependencies and devDependencies to their latest versions and bump the minimum Node.js engine requirement from >=22 to >=24.

## Changes
- Upgrade core dependencies: `@langchain/core` (1.1.27→1.1.29), `ai` (6.0.97→6.0.105)
- Upgrade devDependencies: `@ai-sdk/anthropic`, `@ai-sdk/google`, `@ai-sdk/openai`, `@ai-sdk/togetherai`, `@types/jsdom`, `@types/node`, `eslint`, `rollup`, `typescript-eslint`
- Bump transitive `minimatch` dependencies to latest versions (10.2.4, 9.0.9)
- Update Node.js engine requirement from `>=22` to `>=24` in `package.json` and `package-lock.json`

## Breaking Changes
- [x] Node.js engine requirement changed from `>=22` to `>=24`. Consumers using Node.js 22 or 23 will need to upgrade to Node.js 24+.

## Checklist
- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `npm run lint` `npm run typecheck` `npm run build` `npm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues
N/A
