### PR TITLE
fix: reduce newsletter title max length from 100 to 70 characters

### DIFF
--- a/src/generate-newsletter/llm-queries/generate-newsletter.llm.ts
+++ b/src/generate-newsletter/llm-queries/generate-newsletter.llm.ts
@@ -48,11 +48,7 @@ export default class GenerateNewsletter<TaskId> extends BaseLLMQuery<
   private readonly newsletterBrandName: string;
 
   private readonly schema = z.object({
-    title: z
-      .string()
-      .max(100)
-      .min(20)
-      .describe('Title of the newsletter email'),
+    title: z.string().max(70).min(20).describe('Title of the newsletter email'),
     content: z.string().describe('Email content in markdown format'),
     isWrittenInOutputLanguage: z
       .boolean()
@@ -230,7 +226,7 @@ Output Format & Requirements:
 7. Title Writing Guidelines:${
       this.options.content.titleContext
         ? `\n   - **Required title keyword**: "${this.options.content.titleContext}". This phrase MUST appear in the title. Combine it with key context from today's newsletter content to form a natural, complete title.
-   - Keep title length 20-100 characters and can include 1-2 relevant emoticons.
+   - Keep title length 20-70 characters.
    - Use neutral and objective terms in title (e.g., 'announced', 'implementing', 'deadline approaching').
    - Write title clearly and factually to maintain professionalism and credibility.`
         : `


### PR DESCRIPTION
## Summary
Reduce the maximum allowed newsletter title length from 100 to 70 characters to produce more concise, impactful email subject lines. The Zod schema validation and the LLM prompt guidelines are updated together to keep them in sync.

## Changes
- Update `title` schema max constraint from 100 to 70 in `src/generate-newsletter/llm-queries/generate-newsletter.llm.ts`
- Update title writing guideline prompt text from "20-100 characters" to "20-70 characters" in the same file
- Remove emoticon allowance from the title guideline when `titleContext` is provided

## Breaking Changes
- [x] None

## Checklist
- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `npm run lint` `npm run typecheck` `npm run build` `npm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues
Closes #
