### PR TITLE
feat: enforce temporal validity with publication-date-aware DateService

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ const config: GenerateNewsletterConfig<string> = {
     // titleContext: 'AI Weekly',  // Optional: keyword to include in title
   },
   dateService: {
-    getCurrentISODateString: () => new Date().toISOString().split('T')[0],
-    getDisplayDateString: () => new Date().toLocaleDateString('en-US'),
+    getPublicationISODateString: () => new Date().toISOString().split('T')[0],
+    getPublicationDisplayDateString: () => new Date().toLocaleDateString('en-US'),
   },
   taskService: {
     start: async () => `task-${Date.now()}`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.3.11",
       "license": "Apache-2.0",
       "dependencies": {
-        "@langchain/core": "^1.1.39",
-        "ai": "^6.0.158",
+        "@langchain/core": "^1.1.40",
+        "ai": "^6.0.168",
         "es-toolkit": "^1.45.1",
         "jsdom": "^29.0.2",
         "juice": "^11.1.1",
@@ -18,9 +18,9 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
-        "@ai-sdk/anthropic": "^3.0.69",
-        "@ai-sdk/google": "^3.0.62",
-        "@ai-sdk/openai": "^3.0.52",
+        "@ai-sdk/anthropic": "^3.0.71",
+        "@ai-sdk/google": "^3.0.64",
+        "@ai-sdk/openai": "^3.0.53",
         "@ai-sdk/togetherai": "^2.0.45",
         "@eslint/js": "^10.0.1",
         "@trivago/prettier-plugin-sort-imports": "^6.0.2",
@@ -30,14 +30,14 @@
         "@vitest/expect": "^4.1.4",
         "eslint": "^10.2.0",
         "eslint-plugin-unused-imports": "^4.4.1",
-        "prettier": "^3.8.2",
+        "prettier": "^3.8.3",
         "rimraf": "^6.1.3",
         "rollup": "^4.60.1",
         "rollup-plugin-dts": "^6.4.1",
         "rollup-plugin-typescript2": "^0.37.0",
         "tsx": "^4.21.0",
-        "typescript": "^6.0.2",
-        "typescript-eslint": "^8.58.1",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.58.2",
         "vitest": "^4.1.4"
       },
       "engines": {
@@ -45,9 +45,9 @@
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.69",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.69.tgz",
-      "integrity": "sha512-LshR7X3pFugY0o41G2VKTmg1XoGpSl7uoYWfzk6zjVZLhCfeFiwgpOga+eTV4XY1VVpZwKVqRnkDbIL7K2eH5g==",
+      "version": "3.0.71",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.71.tgz",
+      "integrity": "sha512-bUWOzrzR0gJKJO/PLGMR4uH2dqEgqGhrsCV+sSpk4KtOEnUQlfjZI/F7BFlqSvVpFbjdgYRRLysAeEZpJ6S1lg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -62,14 +62,14 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.95",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.95.tgz",
-      "integrity": "sha512-ZmUNNbZl3V42xwQzPaNUi+s8eqR2lnrxf0bvB6YbLXpLjHYv0k2Y78t12cNOfY0bxGeuVVTLyk856uLuQIuXEQ==",
+      "version": "3.0.104",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.104.tgz",
+      "integrity": "sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.23",
-        "@vercel/oidc": "3.1.0"
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
         "node": ">=18"
@@ -79,9 +79,9 @@
       }
     },
     "node_modules/@ai-sdk/google": {
-      "version": "3.0.62",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.62.tgz",
-      "integrity": "sha512-cC9HAjR5WZxjqGyEJrJqFTlVqyPE9UOFmmGdf5dINaimgfPmzqXYN1qTYEJ+1knbyTVsNMub0KAF5SOqqtO8IQ==",
+      "version": "3.0.64",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.64.tgz",
+      "integrity": "sha512-CbR82EgGPNrj/6q0HtclwuCqe0/pDShyv3nWDP/A9DroujzWXnLMlUJVrgPOsg4b40zQCwwVs2XSKCxvt/4QaA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -96,9 +96,9 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.52",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.52.tgz",
-      "integrity": "sha512-4Rr8NCGmfWTz6DCUvixn9UmyZcMatiHn0zWoMzI3JCUe9R1P/vsPOpCBALKoSzVYOjyJnhtnVIbfUKujcS39uw==",
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
+      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1224,9 +1224,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.1.39",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.39.tgz",
-      "integrity": "sha512-DP9c7TREy6iA7HnywstmUAsNyJNYTFpRg2yBfQ+6H0l1HnvQzei9GsQ36GeOLxgRaD3vm9K8urCcawSC7yQpCw==",
+      "version": "1.1.40",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.40.tgz",
+      "integrity": "sha512-RJ41GQEMxr9ZEZNoIiPgW0+v9nAY6FEZGlk+MjBghr2GR8He50abLam0XCe1aqUJjuKbqt2lUD6M+6SZ+2NIJg==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -2174,17 +2174,17 @@
       "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
-      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
+      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/type-utils": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/type-utils": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2197,7 +2197,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.1",
+        "@typescript-eslint/parser": "^8.58.2",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2213,16 +2213,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
-      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2238,14 +2238,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
-      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
+      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.1",
-        "@typescript-eslint/types": "^8.58.1",
+        "@typescript-eslint/tsconfig-utils": "^8.58.2",
+        "@typescript-eslint/types": "^8.58.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2260,14 +2260,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
-      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
+      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1"
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2278,9 +2278,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
-      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
+      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2295,15 +2295,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
-      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
+      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2320,9 +2320,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
-      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
+      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2334,16 +2334,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
-      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
+      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.1",
-        "@typescript-eslint/tsconfig-utils": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/visitor-keys": "8.58.1",
+        "@typescript-eslint/project-service": "8.58.2",
+        "@typescript-eslint/tsconfig-utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2375,16 +2375,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
-      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.1",
-        "@typescript-eslint/types": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1"
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2399,13 +2399,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
-      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
+      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/types": "8.58.2",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2417,9 +2417,9 @@
       }
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
@@ -2603,12 +2603,12 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.158",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.158.tgz",
-      "integrity": "sha512-gLTp1UXFtMqKUi3XHs33K7UFglbvojkxF/aq337TxnLGOhHIW9+GyP2jwW4hYX87f1es+wId3VQoPRRu9zEStQ==",
+      "version": "6.0.168",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.168.tgz",
+      "integrity": "sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.95",
+        "@ai-sdk/gateway": "3.0.104",
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.23",
         "@opentelemetry/api": "1.9.0"
@@ -3031,9 +3031,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -3888,9 +3888,9 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.18.tgz",
-      "integrity": "sha512-3zuZUWffTHQ+73EAwnodADtf534VNEZUpXr9jC12qyG8/IQuJET7PRsCpTb9wX2lmBspakwLUpqpj3tNm/0bVA==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.20.tgz",
+      "integrity": "sha512-ULhLM8RswvQDXufLtNtvclHrWCBx8Cb5UPI6lAZC+8Dq59iHsVPz/3Ac9khWNm1VIvChRsuykixD/WrmzuuA3Q==",
       "license": "MIT",
       "dependencies": {
         "p-queue": "6.6.2",
@@ -4743,9 +4743,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.2.tgz",
-      "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5278,9 +5278,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5292,16 +5292,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
-      "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
+      "version": "8.58.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
+      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.1",
-        "@typescript-eslint/parser": "8.58.1",
-        "@typescript-eslint/typescript-estree": "8.58.1",
-        "@typescript-eslint/utils": "8.58.1"
+        "@typescript-eslint/eslint-plugin": "8.58.2",
+        "@typescript-eslint/parser": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
   "author": "kimhongyeon",
   "license": "Apache-2.0",
   "dependencies": {
-    "@langchain/core": "^1.1.39",
-    "ai": "^6.0.158",
+    "@langchain/core": "^1.1.40",
+    "ai": "^6.0.168",
     "es-toolkit": "^1.45.1",
     "jsdom": "^29.0.2",
     "juice": "^11.1.1",
@@ -57,9 +57,9 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@ai-sdk/anthropic": "^3.0.69",
-    "@ai-sdk/google": "^3.0.62",
-    "@ai-sdk/openai": "^3.0.52",
+    "@ai-sdk/anthropic": "^3.0.71",
+    "@ai-sdk/google": "^3.0.64",
+    "@ai-sdk/openai": "^3.0.53",
     "@ai-sdk/togetherai": "^2.0.45",
     "@eslint/js": "^10.0.1",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
@@ -69,14 +69,14 @@
     "@vitest/expect": "^4.1.4",
     "eslint": "^10.2.0",
     "eslint-plugin-unused-imports": "^4.4.1",
-    "prettier": "^3.8.2",
+    "prettier": "^3.8.3",
     "rimraf": "^6.1.3",
     "rollup": "^4.60.1",
     "rollup-plugin-dts": "^6.4.1",
     "rollup-plugin-typescript2": "^0.37.0",
     "tsx": "^4.21.0",
-    "typescript": "^6.0.2",
-    "typescript-eslint": "^8.58.1",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.58.2",
     "vitest": "^4.1.4"
   },
   "repository": {

--- a/playground/_shared.ts
+++ b/playground/_shared.ts
@@ -21,8 +21,8 @@ export function createDateService(
   isoDate: string,
 ): DateService {
   return {
-    getDisplayDateString: () => displayDate,
-    getCurrentISODateString: () => isoDate,
+    getPublicationDisplayDateString: () => displayDate,
+    getPublicationISODateString: () => isoDate,
   };
 }
 

--- a/src/generate-newsletter/chains/content-generate.chain.test.ts
+++ b/src/generate-newsletter/chains/content-generate.chain.test.ts
@@ -35,7 +35,7 @@ describe('ContentGenerateChain', () => {
   const createChain = (overrides?: Partial<any>) => {
     const logger = { debug: vi.fn(), info: vi.fn(), error: vi.fn() } as any;
     const dateService = {
-      getCurrentISODateString: vi.fn().mockReturnValue('2024-01-01'),
+      getPublicationISODateString: vi.fn().mockReturnValue('2024-01-01'),
     } as any;
 
     const provider = {

--- a/src/generate-newsletter/chains/content-generate.chain.ts
+++ b/src/generate-newsletter/chains/content-generate.chain.ts
@@ -218,7 +218,7 @@ export default class ContentGenerateChain<TaskId> extends Chain<
             ...coreContent,
             htmlBody: juice(html),
             issueOrder: this.provider.issueOrder,
-            date: this.dateService.getCurrentISODateString(),
+            date: this.dateService.getPublicationISODateString(),
           },
           usedArticles: candidateArticles,
         });

--- a/src/generate-newsletter/llm-queries/determine-article-importance.llm.test.ts
+++ b/src/generate-newsletter/llm-queries/determine-article-importance.llm.test.ts
@@ -41,8 +41,8 @@ describe('DetermineArticleImportance', () => {
       options,
       loggingExecutor,
       dateService: {
-        getCurrentISODateString: () => date,
-        getDisplayDateString: () => date,
+        getPublicationISODateString: () => date,
+        getPublicationDisplayDateString: () => date,
       },
     });
 
@@ -78,17 +78,23 @@ describe('DetermineArticleImportance', () => {
     expect(callArg.system).toContain('AI');
     expect(callArg.system).toContain('Importance Score Criteria (1-10)');
     expect(callArg.system).toContain(
-      '1: Information without current significance',
+      '1: **Information without current practical value**',
     );
     expect(callArg.system).toContain(
       '(However, recent academic achievements maintain high scores)',
     );
+    expect(callArg.system).toContain('as of the Newsletter Publication Date');
+    expect(callArg.system).toContain('HARD RULE — Temporal Expiration');
 
     // user prompt should include date, title, content, tags; exclude Image Analysis
     expect(callArg.prompt).toContain(
       'Please rate the importance of this article from 1 to 10.',
     );
     expect(callArg.prompt).toContain(date);
+    expect(callArg.prompt).toContain('**Newsletter Publication Date:**');
+    expect(callArg.prompt).not.toContain('**Current Date:**');
+    expect(callArg.prompt).not.toContain('**Article Published Date:**');
+    expect(callArg.prompt).toContain('Before assigning a score');
     expect(callArg.prompt).toContain(targetArticle.title);
     expect(callArg.prompt).toContain(targetArticle.detailContent);
     expect(callArg.prompt).toContain(
@@ -139,8 +145,8 @@ describe('DetermineArticleImportance', () => {
       loggingExecutor,
       minimumImportanceScoreRules,
       dateService: {
-        getCurrentISODateString: () => date,
-        getDisplayDateString: () => date,
+        getPublicationISODateString: () => date,
+        getPublicationDisplayDateString: () => date,
       },
     });
 
@@ -163,17 +169,20 @@ describe('DetermineArticleImportance', () => {
     expect(callArg.system).toContain('Robotics');
     expect(callArg.system).toContain('Importance Score Criteria (5-10)');
     expect(callArg.system).not.toContain(
-      '1: Information without current significance',
+      '1: **Information without current practical value**',
     );
     expect(callArg.system).not.toContain(
       '(However, recent academic achievements maintain high scores)',
     );
+    expect(callArg.system).not.toContain('HARD RULE — Temporal Expiration');
 
     // user prompt should include image analysis and correct min point
     expect(callArg.prompt).toContain(
       'Please rate the importance of this article from 5 to 10.',
     );
     expect(callArg.prompt).toContain(date);
+    expect(callArg.prompt).toContain('**Newsletter Publication Date:**');
+    expect(callArg.prompt).not.toContain('Before assigning a score');
     expect(callArg.prompt).toContain(targetArticle.title);
     expect(callArg.prompt).toContain(targetArticle.detailContent);
     expect(callArg.prompt).toContain(
@@ -181,6 +190,60 @@ describe('DetermineArticleImportance', () => {
     );
     expect(callArg.prompt).toContain('**Image Analysis:**');
     expect(callArg.prompt).toContain(targetArticle.imageContextByLlm);
+  });
+
+  test('includes Article Published Date line when targetArticle.publishedDate is provided', async () => {
+    const model: any = { name: 'fake-model-pubdate' };
+    const logger: any = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+    const loggingExecutor: any = {
+      executeWithLogging: vi.fn(async (_taskId: any, fn: any) => fn()),
+    };
+
+    const options: any = {
+      content: { outputLanguage: 'Korean', expertField: 'AI' },
+      llm: { maxRetries: 2 },
+    };
+
+    const targetArticle: any = {
+      targetUrl: 'https://example.com/with-pubdate',
+      title: 'Dated Article',
+      detailContent: 'Body',
+      tag1: 'T1',
+      tag2: 'T2',
+      tag3: 'T3',
+      publishedDate: '2024-05-01',
+    };
+
+    const query = new DetermineArticleImportance({
+      model,
+      logger,
+      taskId: 'task-pubdate',
+      targetArticle,
+      options,
+      loggingExecutor,
+      dateService: {
+        getPublicationISODateString: () => '2024-05-15',
+        getPublicationDisplayDateString: () => 'May 15, 2024',
+      },
+    });
+
+    vi.mocked(generateText).mockResolvedValue({
+      output: { importanceScore: 6 },
+      usage: {},
+    } as any);
+
+    await query.execute();
+
+    const callArg = vi.mocked(generateText).mock.calls[0][0] as any;
+    expect(callArg.prompt).toContain(
+      '**Newsletter Publication Date:** 2024-05-15',
+    );
+    expect(callArg.prompt).toContain('**Article Published Date:** 2024-05-01');
   });
 });
 
@@ -225,8 +288,8 @@ describe('DetermineArticleImportance - fallbacks', () => {
       options,
       loggingExecutor,
       dateService: {
-        getCurrentISODateString: () => date,
-        getDisplayDateString: () => date,
+        getPublicationISODateString: () => date,
+        getPublicationDisplayDateString: () => date,
       },
     });
 

--- a/src/generate-newsletter/llm-queries/determine-article-importance.llm.ts
+++ b/src/generate-newsletter/llm-queries/determine-article-importance.llm.ts
@@ -76,15 +76,25 @@ Importance Score Criteria (${this.minPoint}-10):
 5-6: General important information limited to specific fields or regions (e.g., small project permits, general event notices, small-scale bids)
 4-5: General industry news or small/medium-scale event information
 2-3: Simple information sharing or repetitive daily news
-${this.hasHigherMinimumScore ? '' : `1: Information without current significance - Expired support programs, past events, invalid bid notices or recruitment information, notices that have lost practical value, or administrative/simple notices like "membership fee status", "meeting minutes", "internal schedule notices"`}
+${this.hasHigherMinimumScore ? '' : `1: **Information without current practical value** - Expired support programs, past events, invalid bid notices or recruitment information, notices that have lost practical value, or administrative/simple notices like "membership fee status", "meeting minutes", "internal schedule notices"`}
 
 Evaluation Criteria:
 - Academic Value: Journal publications, research reports, academic seminars/symposiums, research output presentations etc. minimum 7 points (knowledge base expansion and long-term reference value)
 - Practical Impact: Information requiring immediate response like policies, regulations, bids, recruitment
 - Impact Range: How many stakeholders are affected
 - Scarcity: How rare and exclusive the information is
-- Temporal Context: Practical value at current time considering deadlines, event schedules${this.hasHigherMinimumScore ? '' : ' (However, recent academic achievements maintain high scores)'}
-
+- Temporal Context: Practical value as of the Newsletter Publication Date considering deadlines, event schedules${this.hasHigherMinimumScore ? '' : ' (However, recent academic achievements maintain high scores)'}
+${
+  this.hasHigherMinimumScore
+    ? ''
+    : `
+**HARD RULE — Temporal Expiration (MUST):**
+- Compare the Newsletter Publication Date (given in the user prompt) against any deadline, application period, event date, bid closing date, recruitment period, or validity period mentioned in the article (and the Article Published Date when provided).
+- If the article's deadline/event has already passed relative to the Newsletter Publication Date, you MUST score it 1, regardless of other criteria. This overrides all other considerations.
+- Exception: Academic outputs (journal publications, published research, completed conference proceedings) retain their score based on reference value; do not downgrade these under this rule.
+- If no deadline/event is mentioned and no temporal cue is available, this rule does not apply.
+`
+}
 Important Notes:
 - Evaluate considering characteristics and context of ${this.expertFields.join(', ')} fields.
 - Be sensitive to core keywords, events, policies considered important in the field.`;
@@ -93,7 +103,12 @@ Important Notes:
   private get userPrompt() {
     return `Please rate the importance of this article from ${this.minPoint} to 10.
 
-**Current Date:** ${this.dateService.getCurrentISODateString()}
+**Newsletter Publication Date:** ${this.dateService.getPublicationISODateString()}${
+      this.targetArticle.publishedDate
+        ? `
+**Article Published Date:** ${this.targetArticle.publishedDate}`
+        : ''
+    }
 
 **Title:** ${this.targetArticle.title || 'No Title'}
 
@@ -105,6 +120,12 @@ ${
     ? `
 **Image Analysis:** ${this.targetArticle.imageContextByLlm}`
     : ''
-}`;
+}${
+      this.hasHigherMinimumScore
+        ? ''
+        : `
+
+Before assigning a score, explicitly check whether any deadline, application period, event date, bid closing date, or recruitment period in the article has already passed relative to the Newsletter Publication Date above. If so and the HARD RULE applies, assign 1.`
+    }`;
   }
 }

--- a/src/generate-newsletter/llm-queries/generate-newsletter.llm.test.ts
+++ b/src/generate-newsletter/llm-queries/generate-newsletter.llm.test.ts
@@ -16,6 +16,7 @@ function buildArticles() {
       contentType: 'news',
       url: 'https://a.example',
       imageContextByLlm: 'An image description',
+      publishedDate: '2025-05-20',
     },
     {
       title: 'Post B',
@@ -32,7 +33,8 @@ function buildArticles() {
 
 function buildConfig(overrides: Partial<Record<string, any>> = {}) {
   const dateService = {
-    getDisplayDateString: vi.fn().mockReturnValue('June 1-2, 2025'),
+    getPublicationDisplayDateString: vi.fn().mockReturnValue('June 1-2, 2025'),
+    getPublicationISODateString: vi.fn().mockReturnValue('2025-06-01'),
   };
 
   const base = {
@@ -121,6 +123,7 @@ describe('GenerateNewsletter.execute', () => {
     expect(callArg.system).toContain('June 1-2, 2025');
     expect(callArg.system).toContain('Subscribe to TechPulse');
     expect(callArg.system).toContain('https://example.com/subscribe');
+    expect(callArg.system).toContain('Temporal Validity (HARD RULE)');
 
     // user prompt validations
     expect(typeof callArg.prompt).toBe('string');
@@ -130,6 +133,15 @@ describe('GenerateNewsletter.execute', () => {
     expect(callArg.prompt).toContain('**Title:** Post B');
     expect(callArg.prompt).toContain('**Tags:** AI, Policy');
     expect(callArg.prompt).toContain('**Tags:** Cloud, Event');
+    expect(callArg.prompt).toContain(
+      '**Newsletter Publication Date:** 2025-06-01 (June 1-2, 2025)',
+    );
+    expect(callArg.prompt).toContain('TEMPORAL VALIDITY (HIGHEST PRIORITY)');
+    // Post A has publishedDate, Post B does not
+    expect(callArg.prompt).toContain('**Published Date:** 2025-05-20');
+    const publishedDateMatches =
+      callArg.prompt.match(/\*\*Published Date:\*\*/g) ?? [];
+    expect(publishedDateMatches.length).toBe(1);
     // Image Analysis appears only for the first post
     const imageAnalysisMatches =
       callArg.prompt.match(

--- a/src/generate-newsletter/llm-queries/generate-newsletter.llm.ts
+++ b/src/generate-newsletter/llm-queries/generate-newsletter.llm.ts
@@ -143,6 +143,13 @@ Roles:
 - Credibility Builder: All information must be provided with sources. Whenever specific content or titles are mentioned in the body, links must be provided in [original title](URL) format. Understand that source citation is not just formal but a key element in enhancing newsletter credibility and accessibility.
 - Fact Checker: Use only facts from provided source materials. Do not make unsubstantiated claims or speculate beyond the materials.
 
+**Temporal Validity (HARD RULE):**
+The current issue's Newsletter Publication Date is provided in the user prompt. For every article you consider including:
+- If the article's deadline, application period, event date, bid closing date, or recruitment period has already passed relative to the Newsletter Publication Date, you MUST EXCLUDE the article from the newsletter body entirely, regardless of its importance score.
+- Exception: Academic outputs (published journal articles, research outputs, past conference proceedings with reference value) may be retained.
+- If the article provides an Article Published Date and it is older than 30 days relative to the Newsletter Publication Date, treat it as suspicious for freshness and include only if it still has clear forward-looking relevance (e.g., an ongoing program whose deadline has not passed).
+- Do not list or mention excluded articles even as "also notable" or in tables.
+
 **Important Prohibitions:**
 - Do not bundle or omit structured list items (permits/reports/notices etc.) with "... and n more" etc. (tables must list all items in individual rows).
 - Do not describe policies or plans of governments/organizations/companies not explicitly mentioned in sources as facts.
@@ -176,9 +183,9 @@ Copyright Protection & Fact-Checking Principles:
 Output Format & Requirements:
 1. Language: ${this.options.content.outputLanguage}
 
-2. Start: ${this.options.content.freeFormIntro ? 'Begin directly with the Overall Briefing section (no separate opening heading or greeting).' : `Specify date (${this.dateService.getDisplayDateString()}) and begin with neutral, objective greeting. Briefly introduce key factual information to be covered in today's newsletter.`}
+2. Start: ${this.options.content.freeFormIntro ? 'Begin directly with the Overall Briefing section (no separate opening heading or greeting).' : `Specify date (${this.dateService.getPublicationDisplayDateString()}) and begin with neutral, objective greeting. Briefly introduce key factual information to be covered in today's newsletter.`}
 
-3. Overall Briefing: Before the main listing, create a briefing section conveying objective facts about today's news${this.options.content.freeFormIntro ? `. Structure: Start with a Heading 2 (##) briefing section heading in the format "## 📮 ${this.dateService.getDisplayDateString()} [Briefing/Summary word in output language]" (e.g., "## 📮 2월 6일 브리핑" for Korean, "## 📮 Feb 6 Briefing" for English) — do NOT include domain or field names in the heading. Immediately follow with a brief paragraph introducing key factual information to be covered in today's newsletter, then include the following bullet points:` : ' in these aspects:'}
+3. Overall Briefing: Before the main listing, create a briefing section conveying objective facts about today's news${this.options.content.freeFormIntro ? `. Structure: Start with a Heading 2 (##) briefing section heading in the format "## 📮 ${this.dateService.getPublicationDisplayDateString()} [Briefing/Summary word in output language]" (e.g., "## 📮 2월 6일 브리핑" for Korean, "## 📮 Feb 6 Briefing" for English) — do NOT include domain or field names in the heading. Immediately follow with a brief paragraph introducing key factual information to be covered in today's newsletter, then include the following bullet points:` : ' in these aspects:'}
    - Key Trends: Explain major patterns or trends found in this news based on data. Ex: 'Over 00% of today's news relates to 00'.
    - Immediate Impact: Emphasize most important changes or decisions affecting industry immediately, specifically mentioning which fields will be most impacted.
 
@@ -240,7 +247,7 @@ Output Format & Requirements:
 
 8. Additional Requirements:
    - Comprehensively analyze posts to create email containing most important information for ${this.expertFields.join(', ')} field experts.
-   ${this.options.content.freeFormIntro ? '' : `- Naturally include date at beginning in the format: "${this.dateService.getDisplayDateString()} ${this.expertFields.join(', ')} [News Term]". Replace [News Term] with the word for "News" appropriate for the output language (e.g., "News" for English, "소식" for Korean). Declare this part as \`Heading 1\`(#).\n   `}- Write body in markdown format, effectively using headings(#, ##, ###), bold(**), italics(_), bullet points(-, *) etc. to improve readability.
+   ${this.options.content.freeFormIntro ? '' : `- Naturally include date at beginning in the format: "${this.dateService.getPublicationDisplayDateString()} ${this.expertFields.join(', ')} [News Term]". Replace [News Term] with the word for "News" appropriate for the output language (e.g., "News" for English, "소식" for Korean). Declare this part as \`Heading 1\`(#).\n   `}- Write body in markdown format, effectively using headings(#, ##, ###), bold(**), italics(_), bullet points(-, *) etc. to improve readability.
    - Group related news to provide broader context, and mention development status if there's continuity with content covered in previous issues.
    - **Source citation is most important for ensuring credibility.** Must provide links in [original title](URL) format using source's title. Do not write as "View", "Article", "[Post3](URL)" format.
    - Specify source whenever article titles or content are quoted in newsletter, ensure all information is provided with links.
@@ -261,7 +268,7 @@ ${this.targetArticles
 **Importance:** ${post.importanceScore}/10
 **Tags:** ${[post.tag1, post.tag2, post.tag3].filter(Boolean).join(', ')}
 **Content Type:** ${post.contentType}
-**URL:** ${post.url}
+**URL:** ${post.url}${post.publishedDate ? `\n**Published Date:** ${post.publishedDate}` : ''}
 ${post.imageContextByLlm ? `**Image Analysis (supplementary context only — do not cite specific details from this in the newsletter):** ${post.imageContextByLlm}` : ''}
 `,
   )
@@ -270,7 +277,11 @@ ${post.imageContextByLlm ? `**Image Analysis (supplementary context only — do 
 
 ---
 **Comprehensive Analysis and Daily Newsletter Generation Request:**
-Based on all post information provided above, please generate a ${this.expertFields.join(', ')} trends newsletter for ${this.dateService.getDisplayDateString()}. Please note the following:
+**Newsletter Publication Date:** ${this.dateService.getPublicationISODateString()} (${this.dateService.getPublicationDisplayDateString()})
+
+Based on all post information provided above, please generate a ${this.expertFields.join(', ')} trends newsletter for ${this.dateService.getPublicationDisplayDateString()}. Please note the following:
+
+0. **TEMPORAL VALIDITY (HIGHEST PRIORITY):** Before anything else, apply the Temporal Validity HARD RULE from the system prompt. Any post whose deadline/event has passed relative to the Newsletter Publication Date above MUST be excluded from the newsletter body. Do not reference excluded posts anywhere.
 
 1. **STRICT LENGTH CONTROL BY IMPORTANCE SCORE:**
    - 9-10 points: Full detailed coverage allowed (Key Facts + Targets + Dates + Related Facts)

--- a/src/generate-newsletter/models/article.ts
+++ b/src/generate-newsletter/models/article.ts
@@ -1,4 +1,4 @@
-import type { MarkdownString, UrlString } from '~/models/common';
+import type { IsoDateString, MarkdownString, UrlString } from '~/models/common';
 
 /**
  * Structure of an article that has not yet been processed (no importance score, image analysis, or tagging).
@@ -55,6 +55,15 @@ export type UnscoredArticle = {
    * @example "https://example.com/board/notice"
    */
   targetUrl: UrlString;
+
+  /**
+   * (Optional) Original posting/publication date of the article in ISO format (YYYY-MM-DD).
+   * When provided, this is used by LLM queries to judge temporal validity — for example,
+   * whether deadlines or event dates have passed relative to the newsletter publication date.
+   * Implementations that cannot reliably extract this value may omit it.
+   * @example "2024-10-12"
+   */
+  publishedDate?: IsoDateString;
 };
 
 /**

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -36,18 +36,27 @@ export interface EmailService {
 
 /**
  * Service that provides dates for internal use or insertion into the newsletter.
- * Clients can consider locale/language/timezone themselves.
+ *
+ * Semantics: every method on this interface represents the **newsletter publication
+ * date** — i.e. the date the issue is (or will be) published. This may not be
+ * "today" in wall-clock terms: if a caller builds an issue the night before its
+ * scheduled release, they should inject tomorrow's date here.
+ *
+ * Clients are responsible for locale/language/timezone handling in their
+ * implementation.
  */
 export interface DateService {
   /**
-   * Return current date in ISO format (YYYY-MM-DD).
+   * Return the newsletter publication date in ISO format (YYYY-MM-DD).
    * @returns ISO date string
    * @example "2024-10-15"
    */
-  getCurrentISODateString: () => IsoDateString;
+  getPublicationISODateString: () => IsoDateString;
 
   /**
-   * Return a localized display date string for use in newsletter content.
+   * Return a localized display string of the newsletter publication date
+   * for use in newsletter content.
+   * @example "10월 15일"
    */
-  getDisplayDateString: () => string;
+  getPublicationDisplayDateString: () => string;
 }


### PR DESCRIPTION
## Summary
Introduces temporal-validity awareness throughout the newsletter generation pipeline so that stale or expired content (past deadlines, ended events, closed bids/recruitments) is reliably excluded from the output. The `DateService` interface is renamed to reflect that its values represent the **newsletter publication date** (not "now"), and articles can now carry an optional `publishedDate` that LLM queries use for freshness checks. Dev dependencies and the LangChain/AI stack are also bumped to their latest stable releases.

## Changes
- **DateService interface rename** (`src/models/interfaces.ts`): `getCurrentISODateString` → `getPublicationISODateString`, `getDisplayDateString` → `getPublicationDisplayDateString`. JSDoc clarifies that these represent the issue's publication date, not wall-clock "today".
- **Article model** (`src/generate-newsletter/models/article.ts`): add optional `publishedDate: IsoDateString` to `UnscoredArticle` so providers can surface each article's original posting date.
- **Importance scoring** (`src/generate-newsletter/llm-queries/determine-article-importance.llm.ts`): system prompt now includes a `HARD RULE — Temporal Expiration` that forces score `1` for articles whose deadline/event has passed relative to the publication date (academic outputs exempted). User prompt emits `Newsletter Publication Date` and (when available) `Article Published Date`, plus a pre-scoring expiration check instruction. Skipped when `hasHigherMinimumScore` is true.
- **Newsletter generation** (`src/generate-newsletter/llm-queries/generate-newsletter.llm.ts`): system prompt gains a `Temporal Validity (HARD RULE)` section requiring exclusion of expired articles and flagging articles older than 30 days for freshness review. User prompt emits `Newsletter Publication Date`, surfaces per-article `Published Date` when present, and prepends a priority-`0` instruction to apply the rule before anything else.
- **Content chain** (`src/generate-newsletter/chains/content-generate.chain.ts`) and playground/README examples updated to the renamed `DateService` methods.
- **Tests** updated across `determine-article-importance.llm.test.ts`, `generate-newsletter.llm.test.ts`, and `content-generate.chain.test.ts` for the renamed methods, new prompt fragments, and the new `publishedDate` branch (including a dedicated test covering the `Article Published Date` line).
- **Dependencies** (`package.json`, `package-lock.json`): update `@langchain/core`, `ai`, `typescript`, `prettier`, `@typescript-eslint/*`, and related tooling to their latest versions; integrity hashes refreshed.

## Breaking Changes
- [ ] None
- If any, describe migration steps:
  - `DateService` implementations must rename their methods:
    - `getCurrentISODateString` → `getPublicationISODateString`
    - `getDisplayDateString` → `getPublicationDisplayDateString`
  - Callers should inject the **intended publication date** of the issue (which may differ from "today" when building the night before release), not the current clock time.
  - Providers supplying articles via `CrawlingProvider` / `AnalysisProvider` may optionally populate `UnscoredArticle.publishedDate` (ISO `YYYY-MM-DD`) to enable accurate temporal-validity filtering; omitting it preserves previous behavior for articles without a date cue.

## Checklist
- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `npm run lint` `npm run typecheck` `npm run build` `npm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues
Closes #