### PR TITLE
chore: add CI format checks and normalize docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,24 @@
- ## Summary
- Describe the purpose of this PR and the high-level changes.
- 
- ## Changes
- - 
- 
- ## Breaking Changes
- - [ ] None
- - If any, describe migration steps:
- 
- ## Checklist
- - [ ] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- - [ ] I ran: `npm run lint` `npm run typecheck` `npm run build` `npm test`
- - [ ] Tests added/updated; coverage remains 100%
- - [ ] Docs/README updated if needed
- - [ ] No external side effects (network/file/process/time) in tests — use mocks
- 
- ## Related Issues
- Closes #
+## Summary
+
+Describe the purpose of this PR and the high-level changes.
+
+## Changes
+
+-
+
+## Breaking Changes
+
+- [ ] None
+- If any, describe migration steps:
+
+## Checklist
+
+- [ ] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
+- [ ] I ran: `npm run format:check` `npm run lint` `npm run typecheck` `npm run build` `npm test`
+- [ ] Tests added/updated; coverage remains 100%
+- [ ] Docs/README updated if needed
+- [ ] No external side effects (network/file/process/time) in tests — use mocks
+
+## Related Issues
+
+Closes #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    name: Lint, Typecheck, Build, Test
+    name: Format, Lint, Typecheck, Build, Test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -28,6 +28,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Format check
+        run: npm run format:check
 
       - name: Lint (quiet)
         run: npm run lint:ci

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,32 +1,32 @@
- # Contributor Covenant Code of Conduct
- 
- ## Our Pledge
- 
- We as members, contributors, and maintainers pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
- 
- ## Our Standards
- 
- Positive behaviors include using welcoming and inclusive language, being respectful of differing viewpoints and experiences, gracefully accepting constructive criticism, focusing on what is best for the community, and showing empathy towards other community members.
- 
- Unacceptable behaviors include sexualized language or imagery and unwelcome sexual attention or advances, trolling or insulting comments, personal or political attacks, public or private harassment, publishing others’ private information without explicit permission, and other conduct which could reasonably be considered inappropriate in a professional setting.
- 
- ## Scope
- 
- This Code of Conduct applies within all project spaces, and it also applies when an individual is representing the project or its community in public spaces.
- 
- ## Enforcement
- 
- Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers. Preferably contact us privately via the repository’s Security tab or GitHub discussions. For security issues, follow SECURITY.md instead of opening a public issue.
- 
- All complaints will be reviewed and investigated promptly and fairly. The project team will maintain confidentiality with regard to the reporter of an incident.
- 
- ## Enforcement Guidelines
- 
- 1. Correction — Private warning; clarification of expectations.
- 2. Warning — Official warning with consequences for continued behavior.
- 3. Temporary Ban — Temporary ban from interactions/public communication.
- 4. Permanent Ban — Permanent ban for repeated or severe violations.
- 
- ## Attribution
- 
- This Code of Conduct is adapted from the Contributor Covenant, version 2.1: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Positive behaviors include using welcoming and inclusive language, being respectful of differing viewpoints and experiences, gracefully accepting constructive criticism, focusing on what is best for the community, and showing empathy towards other community members.
+
+Unacceptable behaviors include sexualized language or imagery and unwelcome sexual attention or advances, trolling or insulting comments, personal or political attacks, public or private harassment, publishing others’ private information without explicit permission, and other conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when an individual is representing the project or its community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers. Preferably contact us privately via the repository’s Security tab or GitHub discussions. For security issues, follow SECURITY.md instead of opening a public issue.
+
+All complaints will be reviewed and investigated promptly and fairly. The project team will maintain confidentiality with regard to the reporter of an incident.
+
+## Enforcement Guidelines
+
+1.  Correction — Private warning; clarification of expectations.
+2.  Warning — Official warning with consequences for continued behavior.
+3.  Temporary Ban — Temporary ban from interactions/public communication.
+4.  Permanent Ban — Permanent ban for repeated or severe violations.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 2.1: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,13 @@
 Thank you for your interest in this project! This guide concisely explains local development, testing, code style, and the PR process.
 
 ## Development Environment
+
 - Node.js: >= 22 (CI verified on 24.x)
 - Package manager: npm (with package-lock.json)
 - Language/Runtime: TypeScript, ESM (ES2022)
 
 ### Project Setup
+
 ```bash
 npm ci
 npm run typecheck
@@ -16,19 +18,22 @@ npm test
 ```
 
 ### Useful Scripts
+
 - Build: `npm run build` (Rollup, generates CJS/ESM/d.ts in dist)
 - Test: `npm run test` / `npm run test:watch` / `npm run test:coverage`
 - Coverage (CI mode): `npm run test:ci`
 - Lint: `npm run lint` / auto fix `npm run lint:fix`
 - Typecheck: `npm run typecheck`
-- Format: `npm run format`
+- Format: `npm run format` / check `npm run format:check`
 
 ## Code Style
+
 - ESLint (typescript-eslint), Prettier
 - Import sorting: `@trivago/prettier-plugin-sort-imports`
-- Before committing: run `npm run lint` `npm run typecheck` `npm test`
+- Before committing: run `npm run format:check` `npm run lint` `npm run typecheck` `npm test`
 
 ## Testing Guide
+
 - Test runner: Vitest
 - Environment: Node (`environment: 'node'`), ESM, globals `describe/test/expect/vi`
 - Config: `vitest.config.ts`, global mocks in `vitest.setup.ts`
@@ -36,6 +41,7 @@ npm test
 - Coverage: v8, threshold 100% (lines/functions/branches/statements)
 
 ### Mocking Principles
+
 - Mock all side effects: network/file/process/time/randomness
 - Do not re-`vi.mock` modules already mocked globally; instead control behavior with `vi.mocked(...).mockResolvedValue`/`mockRejectedValue`, etc.
   - `ai`, `@langchain/core/runnables`
@@ -46,6 +52,7 @@ npm test
 - Make time/randomness deterministic (`Date.now`, `crypto.randomUUID`)
 
 ## Architecture / Public API
+
 - Entry: `src/index.ts`
   - Default export: `GenerateNewsletter` class
   - Type exports: Crawling/Analysis/ContentGenerate providers, TaskService, DateService, EmailService, Newsletter, and domain models
@@ -55,21 +62,25 @@ npm test
 ## Fork & Pull Request Workflow
 
 ### 1. Fork the Repository
+
 Click "Fork" button on GitHub: https://github.com/heripo-lab/llm-newsletter-kit-core
 
 ### 2. Clone Your Fork
+
 ```bash
 git clone https://github.com/YOUR_USERNAME/llm-newsletter-kit-core.git
 cd llm-newsletter-kit-core
 ```
 
 ### 3. Add Upstream Remote
+
 ```bash
 git remote add upstream https://github.com/heripo-lab/llm-newsletter-kit-core.git
 git remote -v  # Verify: origin (your fork), upstream (original repo)
 ```
 
 ### 4. Create a Branch
+
 ```bash
 git checkout -b feat/your-feature-name
 # or: fix/bug-description, docs/update-readme, etc.
@@ -78,6 +89,7 @@ git checkout -b feat/your-feature-name
 Branch naming: `feat/...`, `fix/...`, `chore/...`, `docs/...`, `test/...`
 
 ### 5. Make Changes & Test Locally
+
 ```bash
 # Install dependencies
 npm ci
@@ -93,6 +105,7 @@ npm run test:coverage
 ```
 
 ### 6. Commit Your Changes
+
 ```bash
 git add .
 git commit -m "feat: add amazing feature"
@@ -101,11 +114,13 @@ git commit -m "feat: add amazing feature"
 Commit messages: Use Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`)
 
 ### 7. Push to Your Fork
+
 ```bash
 git push origin feat/your-feature-name
 ```
 
 ### 8. Create Pull Request
+
 1. Go to your fork on GitHub: `https://github.com/YOUR_USERNAME/llm-newsletter-kit-core`
 2. Click "Compare & pull request" button
 3. Base repository: `heripo-lab/llm-newsletter-kit-core` base: `main`
@@ -114,6 +129,7 @@ git push origin feat/your-feature-name
 6. Submit!
 
 ### 9. Respond to Review Feedback
+
 ```bash
 # Make requested changes
 git add .
@@ -124,6 +140,7 @@ git push origin feat/your-feature-name
 ```
 
 ### 10. Keep Your Fork Updated
+
 ```bash
 git checkout main
 git fetch upstream
@@ -132,9 +149,10 @@ git push origin main
 ```
 
 ## PR Checklist
+
 - [ ] Forked repo and created feature branch
 - [ ] Add unit tests for features/fixes; keep coverage at 100%
-- [ ] Pass locally: `npm run lint` `npm run typecheck` `npm run build` `npm test`
+- [ ] Pass locally: `npm run format:check` `npm run lint` `npm run typecheck` `npm run build` `npm test`
 - [ ] Update README/docs if needed
 - [ ] No external side-effect calls (use mocks)
 - [ ] Add meaningful logging/error handling where appropriate
@@ -142,16 +160,19 @@ git push origin main
 - [ ] PR description explains what/why/how
 
 ## Release (Maintainers)
+
 - Version/Publish: `npm version {patch|minor|major}` → `npm publish --access public`
   - Scripts: `release:*` (auto build via `prepublishOnly`/`preversion`), `postversion` pushes tags
 - Distribution artifacts: `dist` directory (exports: ESM/CJS/types)
 
 ## CI
+
 - Location: `.github/workflows/ci.yml`
 - Triggers: Pull Request, manual
-- Steps: Lint → Typecheck → Build → Test (coverage) → upload dist/coverage artifacts
+- Steps: Format check → Lint → Typecheck → Build → Test (coverage) → upload dist/coverage artifacts
 - Node version: 24.x
 
 ## Issues / Questions
+
 - Please open GitHub Issues for bug reports/feature requests.
 - Include reproduction steps, expected/actual results, logs/screenshots to speed up review.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 > **Automate domain-expert newsletters powered by AI**
 
 [
-  ![CI](https://github.com/heripo-lab/llm-newsletter-kit-core/actions/workflows/ci.yml/badge.svg)
+![CI](https://github.com/heripo-lab/llm-newsletter-kit-core/actions/workflows/ci.yml/badge.svg)
 ](https://github.com/heripo-lab/llm-newsletter-kit-core/actions/workflows/ci.yml)
 [
-  ![npm version](https://img.shields.io/npm/v/%40llm-newsletter-kit/core?logo=npm&color=cb0000)
+![npm version](https://img.shields.io/npm/v/%40llm-newsletter-kit/core?logo=npm&color=cb0000)
 ](https://www.npmjs.com/package/@llm-newsletter-kit/core)
 ![coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)
 ![license](https://img.shields.io/github/license/heripo-lab/llm-newsletter-kit-core)
@@ -27,11 +27,12 @@ A type‑first, extensible toolkit that automates LLM‑based newsletter creatio
 
 This project originated from a **Korean cultural heritage newsletter service** called “Research Radar.”
 
-It was architected by **Kim Hongyeon**, a unique **archaeologist-turned-software engineer**. Driven by a question he held for over a decade—***"Why must research be such grueling manual labor?"***—he combined his domain expertise with 10+ years of engineering experience to solve this problem.
+It was architected by **Kim Hongyeon**, a unique **archaeologist-turned-software engineer**. Driven by a question he held for over a decade—**_"Why must research be such grueling manual labor?"_**—he combined his domain expertise with 10+ years of engineering experience to solve this problem.
 
 After completing an academic research project on [A Study on Archaeological Informatization Using Large Language Models (LLMs)](https://poc.heripo.org), a personal automation script created to keep up with academic trends evolved into a service with a high engagement rate (15% CTR) and near-zero maintenance cost.
 
 **Real-world production metrics:**
+
 - **LLM API cost:** $0.2-1 USD per issue with optimized model usage
 - **Operational overhead:** Truly hands-off automation—runs 24/7 without human intervention; the only ongoing work is occasional code maintenance
 - **Time investment:** Set it up once, let it run indefinitely; it operates while you sleep
@@ -44,6 +45,7 @@ His design philosophy: **"Logic in code, reasoning in AI, connections in archite
 - **Research Radar (Reference Implementation):** A real-world application built with this Core. It serves as a live demo and a "preset" for how to implement the providers.
 
 **Quick Links**
+
 - Research Radar (Live Service): https://heripo.app/research-radar/subscribe
 - Source Code (Usage Example): https://github.com/heripo-lab/heripo-research-radar
 
@@ -52,6 +54,7 @@ His design philosophy: **"Logic in code, reasoning in AI, connections in archite
 Newsletter automation generally falls into two approaches: no-code and code-based. **This kit takes the code-based approach because it produces significantly better output quality.**
 
 **Key advantages:**
+
 - **Advanced AI workflows**: Implement sophisticated techniques like self-reflection, chain-of-thought reasoning, and multi-step verification—impossible or prohibitively expensive in no-code platforms
 - **Cost control**: Use different models per stage, cap tokens, control retries, and prevent runaway costs with granular configuration
 - **Full customization**: Swap any component (crawlers, LLMs, databases, email) via Provider interfaces without vendor lock-in
@@ -73,9 +76,10 @@ npm i @llm-newsletter-kit/core
 ## Quick Start
 
 ```ts
-import { GenerateNewsletter } from '@llm-newsletter-kit/core';
 import type { GenerateNewsletterConfig } from '@llm-newsletter-kit/core';
+
 import { createOpenAI } from '@ai-sdk/openai';
+import { GenerateNewsletter } from '@llm-newsletter-kit/core';
 
 const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
@@ -88,7 +92,8 @@ const config: GenerateNewsletterConfig<string> = {
   },
   dateService: {
     getPublicationISODateString: () => new Date().toISOString().split('T')[0],
-    getPublicationDisplayDateString: () => new Date().toLocaleDateString('en-US'),
+    getPublicationDisplayDateString: () =>
+      new Date().toLocaleDateString('en-US'),
   },
   taskService: {
     start: async () => `task-${Date.now()}`,
@@ -96,8 +101,12 @@ const config: GenerateNewsletterConfig<string> = {
   },
   crawlingProvider: {
     // customFetch: myProxyFetch,  // Optional: custom fetch for proxy support
-    crawlingTargetGroups: [/* ... */],
-    fetchExistingArticlesByUrls: async (urls) => [/* ... */],
+    crawlingTargetGroups: [
+      /* ... */
+    ],
+    fetchExistingArticlesByUrls: async (urls) => [
+      /* ... */
+    ],
     saveCrawledArticles: async (articles, context) => articles.length,
   },
   analysisProvider: {
@@ -105,8 +114,12 @@ const config: GenerateNewsletterConfig<string> = {
     classifyTagOptions: { model: openai('gpt-5-mini') },
     analyzeImagesOptions: { model: openai('gpt-5.1') },
     determineScoreOptions: { model: openai('gpt-5.1') },
-    fetchUnscoredArticles: async () => [/* ... */],
-    fetchTags: async () => [/* ... */],
+    fetchUnscoredArticles: async () => [
+      /* ... */
+    ],
+    fetchTags: async () => [
+      /* ... */
+    ],
     update: async (article) => {},
   },
   contentGenerateProvider: {
@@ -115,7 +128,9 @@ const config: GenerateNewsletterConfig<string> = {
     issueOrder: 1,
     newsletterBrandName: 'Tech Insight Weekly',
     publicationCriteria: { minimumArticleCountForIssue: 5 },
-    fetchArticleCandidates: async () => [/* ... */],
+    fetchArticleCandidates: async () => [
+      /* ... */
+    ],
     htmlTemplate: ({ content }) => `<html>...</html>`,
     saveNewsletter: async ({ newsletter }) => ({ id: 1 }),
   },
@@ -126,6 +141,7 @@ const newsletterId = await generator.generate();
 ```
 
 **⚠️ This is a minimal example showing the structure. For a complete, production-ready implementation with:**
+
 - Real database integration (Prisma/Drizzle)
 - Actual crawling targets and parsing logic
 - HTML email templates
@@ -153,10 +169,10 @@ For detailed field descriptions, see `src/generate-newsletter/models/interfaces.
 
 ## Architecture & Flow
 
-1) CrawlingChain: Collect/parse/save articles from targets
-2) AnalysisChain: Tagging/image analysis/importance scoring and update
-3) ContentGenerateChain: Select candidates → generate Markdown via LLM → apply template (HTML) → save → return id
-4) If previewNewsletter option is present, send a preview email
+1. CrawlingChain: Collect/parse/save articles from targets
+2. AnalysisChain: Tagging/image analysis/importance scoring and update
+3. ContentGenerateChain: Select candidates → generate Markdown via LLM → apply template (HTML) → save → return id
+4. If previewNewsletter option is present, send a preview email
 
 All chains are composed as a single pipeline using `@langchain/core/runnables` sequence.
 
@@ -177,11 +193,13 @@ Playground scripts let you run individual LLM query classes in isolation — no 
 ### Setup
 
 1. Install playground dependencies:
+
    ```bash
    npm install -D tsx @ai-sdk/openai
    ```
 
 2. Copy example data files and customize:
+
    ```bash
    mkdir -p playground/data
    cp playground/data-examples/config.example.json playground/data/config.json
@@ -202,16 +220,17 @@ npm run playground:generate-newsletter
 ### Output
 
 Results are saved to `playground/output/` (git-ignored):
+
 - `newsletter.md` — Generated markdown with title in frontmatter
 - `newsletter.html` — Rendered HTML with CSS inlined (juice)
 
 ### Data Management
 
-| Directory | Git | Purpose |
-|---|---|---|
-| `playground/data-examples/` | Tracked | Format reference files (`.example.*`) |
-| `playground/data/` | Ignored | Your actual config, articles, templates |
-| `playground/output/` | Ignored | Generated results |
+| Directory                   | Git     | Purpose                                 |
+| --------------------------- | ------- | --------------------------------------- |
+| `playground/data-examples/` | Tracked | Format reference files (`.example.*`)   |
+| `playground/data/`          | Ignored | Your actual config, articles, templates |
+| `playground/output/`        | Ignored | Generated results                       |
 
 ## Development / Build / Test / CI
 
@@ -220,6 +239,7 @@ For the full developer guide (environment, scripts, testing/coverage, and CI), s
 ## Contributing & Policies
 
 Please refer to [CONTRIBUTING.md](./CONTRIBUTING.md) for all contribution guidelines and project policies, including:
+
 - Issue labels and triage
 - Branch strategy and PR process
 - Versioning and release policy

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,34 +1,35 @@
- # Security Policy
- 
- We take the security of this project seriously and appreciate responsible disclosures.
- 
- ## Supported Versions
- 
- We generally support the latest published version on npm. Older versions may not receive security fixes.
- 
- | Version | Supported |
- | ------- | --------- |
- | latest  | yes       |
- | < latest | no       |
- 
- ## Reporting a Vulnerability
- 
- Please do NOT open public GitHub issues for security vulnerabilities.
- 
- - Use GitHub Security Advisories to privately report issues: https://github.com/heripo-lab/llm-newsletter-kit-core/security/advisories/new
- - Alternatively, you can reach out via GitHub Discussions if you’re unsure whether a finding is security-related.
- 
- Provide as much detail as possible:
- - Affected version(s)
- - Environment (Node.js version, OS)
- - Reproduction steps or proof-of-concept
- - Impact assessment (what can an attacker achieve)
- 
- ## Disclosure Policy
- 
- - We will acknowledge receipt within 3 business days.
- - We will investigate and provide an initial assessment within 7 business days.
- - We will work with you to validate, remediate, and coordinate a disclosure timeline.
- - We prefer coordinated disclosure; we will publish an advisory and release a patched version before public disclosure whenever possible.
- 
- Thank you for helping keep the community safe.
+# Security Policy
+
+We take the security of this project seriously and appreciate responsible disclosures.
+
+## Supported Versions
+
+We generally support the latest published version on npm. Older versions may not receive security fixes.
+
+| Version  | Supported |
+| -------- | --------- |
+| latest   | yes       |
+| < latest | no        |
+
+## Reporting a Vulnerability
+
+Please do NOT open public GitHub issues for security vulnerabilities.
+
+- Use GitHub Security Advisories to privately report issues: https://github.com/heripo-lab/llm-newsletter-kit-core/security/advisories/new
+- Alternatively, you can reach out via GitHub Discussions if you’re unsure whether a finding is security-related.
+
+Provide as much detail as possible:
+
+- Affected version(s)
+- Environment (Node.js version, OS)
+- Reproduction steps or proof-of-concept
+- Impact assessment (what can an attacker achieve)
+
+## Disclosure Policy
+
+- We will acknowledge receipt within 3 business days.
+- We will investigate and provide an initial assessment within 7 business days.
+- We will work with you to validate, remediate, and coordinate a disclosure timeline.
+- We prefer coordinated disclosure; we will publish an advisory and release a patched version before public disclosure whenever possible.
+
+Thank you for helping keep the community safe.

--- a/__mocks__/@langchain/core/runnables.ts
+++ b/__mocks__/@langchain/core/runnables.ts
@@ -4,7 +4,8 @@
 // Internal state for assertions/control
 const assignCalls: Array<Record<string, any>> = [];
 const fromCalls: Array<any[]> = [];
-let sequenceInvokeImpl: () => Promise<any> = async () => 'SEQUENCE_RESULT' as any;
+let sequenceInvokeImpl: () => Promise<any> = async () =>
+  'SEQUENCE_RESULT' as any;
 
 // Utility to build a pipeline step from a mapping
 // Each mapping entry is a function that receives the current context and returns a value for that key
@@ -25,9 +26,9 @@ function assign(mapping: Record<string, any>) {
   assignCalls.push(mapping);
 
   // steps start with initial mapping application
-  const steps: Array<(ctx: Record<string, any>) => Promise<Record<string, any>>> = [
-    makeStep(mapping as any),
-  ];
+  const steps: Array<
+    (ctx: Record<string, any>) => Promise<Record<string, any>>
+  > = [makeStep(mapping as any)];
 
   const pipeline: any = {
     // Expose mapping keys directly so callers can access functions like top['group-1']()
@@ -39,7 +40,9 @@ function assign(mapping: Record<string, any>) {
           return await next.invoke(ctx);
         });
       } else {
-        steps.push(makeStep(next as Record<string, (ctx: Record<string, any>) => any>));
+        steps.push(
+          makeStep(next as Record<string, (ctx: Record<string, any>) => any>),
+        );
       }
       return pipeline;
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "lint:fix": "eslint --fix ./src",
     "lint:ci": "eslint --quiet ./src",
     "typecheck": "tsc --noEmit",
-    "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md,mdx}\"",
+    "format": "prettier --write \"**/*.{ts,tsx,js,jsx,mjs,json,md,mdx}\"",
+    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mjs,json,md,mdx}\"",
     "playground": "tsx",
     "playground:generate-newsletter": "tsx playground/generate-newsletter.ts"
   },

--- a/playground/_shared.ts
+++ b/playground/_shared.ts
@@ -1,8 +1,8 @@
-import { readFile, mkdir } from 'node:fs/promises';
+import type { AppLogger, DateService } from '@llm-newsletter-kit/core';
+
+import { mkdir, readFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-
-import type { AppLogger, DateService } from '@llm-newsletter-kit/core';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,4 @@
 import { resolve } from 'node:path';
-
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -16,7 +16,7 @@ vi.mock('~/utils/string', async () => {
   return await vi.importActual('./src/utils/string');
 });
 vi.mock('~/utils/markdown-to-html', async () => ({
-  default: vi.fn((s: string) => s)
+  default: vi.fn((s: string) => s),
 }));
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary

This PR makes formatting a first-class quality gate by adding Prettier verification to CI and the PR checklist. It also normalizes existing Markdown and TypeScript formatting so the repository can pass the expanded format check consistently.

## Changes

- Added `format:check` to `package.json` and expanded the `format` glob to cover repository Markdown, JSON, JavaScript, TypeScript, MDX, and MJS files.
- Added a `Format check` step to `.github/workflows/ci.yml` and updated the CI job name to include formatting.
- Updated `.github/pull_request_template.md` and `CONTRIBUTING.md` so contributor instructions include `npm run format:check`.
- Normalized Markdown formatting in `README.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, and `SECURITY.md`.
- Applied Prettier/import-order formatting to `__mocks__/@langchain/core/runnables.ts`, `playground/_shared.ts`, `vitest.config.ts`, and `vitest.setup.ts`.

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `npm run format:check` `npm run lint` `npm run typecheck` `npm run build` `npm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #