### PR TITLE
chore(deps): bump brace-expansion to 5.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2734,9 +2734,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Bumps the locked `brace-expansion` dev dependency from `5.0.5` to `5.0.6`. This keeps the npm lockfile aligned with the latest patch release and refreshes the package resolution metadata.

## Changes

- Updated `node_modules/brace-expansion` in `package-lock.json` from `5.0.5` to `5.0.6`
- Refreshed the resolved npm tarball URL and integrity hash for `brace-expansion`

## Breaking Changes

- [x] None
- If any, describe migration steps:

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `npm run format:check` `npm run lint` `npm run typecheck` `npm run build` `npm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #