### PR TITLE
feat: add PromptProvider interface for external LLM prompt injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,88 @@ const newsletterId = await generator.generate();
 
 👉 **See the reference implementation: https://github.com/heripo-lab/heripo-research-radar**
 
+## Customizing LLM Prompts (PromptProvider)
+
+The kit ships with built-in prompts designed to cover a wide range of domains. However, these general-purpose prompts may not be flexible enough for specialized requirements. For example:
+
+- Your domain uses unique terminology or jargon that the default prompts don't account for
+- You need a specific newsletter tone or structure (e.g., academic style, casual briefing)
+- Tag classification requires domain-specific taxonomy rules
+- Importance scoring needs custom criteria tailored to your industry
+
+`PromptProvider` lets you **replace** any built-in prompt — system prompt, user prompt, or both — on a per-stage basis while keeping the rest of the pipeline intact.
+
+### How It Works
+
+PromptProvider is organized by pipeline stage. Every field is optional — omitted prompts fall back to the built-in defaults.
+
+```
+PromptProvider
+├── analysis
+│   ├── classifyTags        — Tag classification (system / user)
+│   ├── analyzeImages       — Image analysis (system / user)
+│   └── determineImportance — Importance scoring (system / user)
+└── contentGenerate
+    └── generateNewsletter  — Final newsletter generation (system / user)
+```
+
+Each prompt slot is a `PromptBuilder<TContext>` — an object with optional `system` and `user` functions. The function receives a typed context object containing all the data the default prompt would use (articles, tags, expert fields, dates, etc.), so you have full control over prompt construction.
+
+> **Dependency note:** Analysis prompts (classifyTags → analyzeImages → determineImportance) produce data that flows into the content generation prompt. Changing an analysis prompt may indirectly affect the final newsletter output.
+
+### Example
+
+```ts
+import type {
+  GenerateNewsletterConfig,
+  PromptProvider,
+} from '@llm-newsletter-kit/core';
+
+const promptProvider: PromptProvider = {
+  analysis: {
+    // Override only the system prompt for tag classification
+    classifyTags: {
+      system: (ctx) =>
+        `You are a legal-domain specialist. Classify articles using ` +
+        `legal taxonomy standards. Available tags: ${ctx.existTags.join(', ')}. ` +
+        `Output language: ${ctx.outputLanguage}.`,
+      // user prompt falls back to the built-in default
+    },
+    // Override importance scoring with domain-specific criteria
+    determineImportance: {
+      system: (ctx) =>
+        `Score article importance for ${ctx.expertFields.join(', ')} professionals. ` +
+        `Regulatory changes and court rulings score 8+. ` +
+        `Commentary and opinion pieces score 3-5.`,
+      user: (ctx) =>
+        `Article: ${ctx.targetArticle.title}\n` +
+        `Content: ${ctx.targetArticle.detailContent}\n` +
+        `Score this article 1-10.`,
+    },
+  },
+  contentGenerate: {
+    // Override the newsletter generation prompt entirely
+    generateNewsletter: {
+      system: (ctx) =>
+        `You produce a weekly legal digest for "${ctx.newsletterBrandName}". ` +
+        `Write in ${ctx.outputLanguage}. Use formal academic tone.`,
+      user: (ctx) =>
+        `Publication date: ${ctx.dateService.getPublicationDisplayDateString()}\n\n` +
+        ctx.targetArticles
+          .map((a) => `- [${a.title}](${a.url}) (score: ${a.importanceScore})`)
+          .join('\n'),
+    },
+  },
+};
+
+const config: GenerateNewsletterConfig<string> = {
+  // ... other config (contentOptions, dateService, taskService, providers, etc.)
+  promptProvider, // Inject custom prompts
+};
+```
+
+For full context types (`ClassifyTagsPromptContext`, `GenerateNewsletterPromptContext`, etc.), see `src/generate-newsletter/models/prompt-provider.ts`.
+
 ## Public API Overview
 
 Entry point: `src/index.ts`
@@ -163,6 +245,7 @@ Entry point: `src/index.ts`
   - AnalysisProvider { classifyTagOptions.model, analyzeImagesOptions.model, determineScoreOptions(model, minimumImportanceScoreRules), fetchUnscoredArticles, fetchTags, update }
   - ContentGenerateProvider { model and generation options, issueOrder, publicationCriteria, subscribePageUrl, newsletterBrandName, fetchArticleCandidates, htmlTemplate, saveNewsletter }
   - GenerateNewsletterOptions { logger, llm, chain, previewNewsletter(emailService/emailMessage/fetchNewsletterForPreview) }
+  - PromptProvider { analysis?(classifyTags, analyzeImages, determineImportance), contentGenerate?(generateNewsletter) }
   - Domain models: DateService, EmailService, Newsletter, etc.
 
 For detailed field descriptions, see `src/generate-newsletter/models/interfaces.ts` and type definitions under `src/models/*`.

--- a/src/generate-newsletter.ts
+++ b/src/generate-newsletter.ts
@@ -12,6 +12,7 @@ import type {
   TaskService,
 } from '~/generate-newsletter/models/interfaces';
 import type { CommonProcessingOptions } from '~/generate-newsletter/models/options';
+import type { PromptProvider } from '~/generate-newsletter/models/prompt-provider';
 import { LoggingExecutor } from '~/logging/logging-executor';
 import type { AppLogger, DateService } from '~/models/interfaces';
 
@@ -28,6 +29,7 @@ export default class GenerateNewsletter<TaskId> {
   private readonly contentGenerateProvider: ContentGenerateProvider;
   private readonly logger: AppLogger;
   private readonly options: CommonProcessingOptions;
+  private readonly promptProvider?: PromptProvider;
   private readonly previewNewsletterOptions?: GenerateNewsletterOptions['previewNewsletter'];
 
   /** Independent internal field **/
@@ -75,6 +77,8 @@ export default class GenerateNewsletter<TaskId> {
       },
     };
 
+    this.promptProvider = config.promptProvider;
+
     // Default logger (no-op)
     this.logger = config.options?.logger ?? {
       info: (_msg) => {},
@@ -111,6 +115,7 @@ export default class GenerateNewsletter<TaskId> {
         options: this.options,
         loggingExecutor,
         dateService: this.dateService,
+        promptProvider: this.promptProvider?.analysis,
       });
 
       const contentGenerateChain = new ContentGenerateChain({
@@ -120,6 +125,7 @@ export default class GenerateNewsletter<TaskId> {
         options: this.options,
         loggingExecutor,
         dateService: this.dateService,
+        promptProvider: this.promptProvider?.contentGenerate,
       });
 
       const taskChain = RunnableSequence.from([

--- a/src/generate-newsletter/chains/analysis.chain.ts
+++ b/src/generate-newsletter/chains/analysis.chain.ts
@@ -7,6 +7,7 @@ import type { AnalysisProvider } from '../models/interfaces';
 import { RunnablePassthrough } from '@langchain/core/runnables';
 
 import { LoggingExecutor } from '~/logging/logging-executor';
+import type { PromptProvider } from '~/generate-newsletter/models/prompt-provider';
 import type { DateService } from '~/models/interfaces';
 
 import ArticleInsightsChain from './article-insights.chain';
@@ -14,6 +15,7 @@ import { Chain, type ChainConfig } from './chain';
 
 type Config<TaskId> = ChainConfig<TaskId, AnalysisProvider> & {
   dateService: DateService;
+  promptProvider?: PromptProvider['analysis'];
 };
 
 export default class AnalysisChain<TaskId> extends Chain<
@@ -21,11 +23,13 @@ export default class AnalysisChain<TaskId> extends Chain<
   AnalysisProvider
 > {
   private readonly dateService: DateService;
+  private readonly promptProvider?: PromptProvider['analysis'];
 
   constructor(config: Config<TaskId>) {
     super(config);
 
     this.dateService = config.dateService;
+    this.promptProvider = config.promptProvider;
   }
 
   public get chain() {
@@ -105,6 +109,7 @@ export default class AnalysisChain<TaskId> extends Chain<
             this.taskId as TaskId,
           ),
           dateService: this.dateService,
+          promptProvider: this.promptProvider,
         });
 
         return await articleInsightsChain.generateInsights();

--- a/src/generate-newsletter/chains/analysis.chain.ts
+++ b/src/generate-newsletter/chains/analysis.chain.ts
@@ -6,8 +6,8 @@ import type { AnalysisProvider } from '../models/interfaces';
 
 import { RunnablePassthrough } from '@langchain/core/runnables';
 
-import { LoggingExecutor } from '~/logging/logging-executor';
 import type { PromptProvider } from '~/generate-newsletter/models/prompt-provider';
+import { LoggingExecutor } from '~/logging/logging-executor';
 import type { DateService } from '~/models/interfaces';
 
 import ArticleInsightsChain from './article-insights.chain';

--- a/src/generate-newsletter/chains/article-insights.chain.ts
+++ b/src/generate-newsletter/chains/article-insights.chain.ts
@@ -10,6 +10,7 @@ import { RunnablePassthrough } from '@langchain/core/runnables';
 import { pick } from 'es-toolkit';
 
 import type { AnalysisProvider } from '~/generate-newsletter/models/interfaces';
+import type { PromptProvider } from '~/generate-newsletter/models/prompt-provider';
 import { LoggingExecutor } from '~/logging/logging-executor';
 import type { DateService } from '~/models/interfaces';
 
@@ -34,6 +35,7 @@ export type ArticleInsights = {
 
 type Config<TaskId> = ChainConfig<TaskId, ArticleInsights> & {
   dateService: DateService;
+  promptProvider?: PromptProvider['analysis'];
 };
 
 export default class ArticleInsightsChain<TaskId> extends PrivateChain<
@@ -41,11 +43,13 @@ export default class ArticleInsightsChain<TaskId> extends PrivateChain<
   ArticleInsights
 > {
   private readonly dateService: DateService;
+  private readonly promptProvider?: PromptProvider['analysis'];
 
   constructor(config: Config<TaskId>) {
     super(config);
 
     this.dateService = config.dateService;
+    this.promptProvider = config.promptProvider;
   }
 
   /* istanbul ignore next - pipeline arrow functions are exercised via higher-level tests */
@@ -177,12 +181,13 @@ export default class ArticleInsightsChain<TaskId> extends PrivateChain<
           });
 
           try {
-            const classifyTags = new ClassifyTags(
-              this.getLlmQueryConfig(
+            const classifyTags = new ClassifyTags({
+              ...this.getLlmQueryConfig(
                 this.provider.classifyTagOptions.model,
                 article,
               ),
-            );
+              promptBuilder: this.promptProvider?.classifyTags,
+            });
 
             const { result: generatedTags } = await classifyTags.execute({
               existTags,
@@ -272,12 +277,13 @@ export default class ArticleInsightsChain<TaskId> extends PrivateChain<
           });
 
           try {
-            const analyzeImages = new AnalyzeImages(
-              this.getLlmQueryConfig(
+            const analyzeImages = new AnalyzeImages({
+              ...this.getLlmQueryConfig(
                 this.provider.analyzeImagesOptions.model,
                 article,
               ),
-            );
+              promptBuilder: this.promptProvider?.analyzeImages,
+            });
 
             const { result: imageContextByLlm } = await analyzeImages.execute();
 
@@ -405,6 +411,7 @@ export default class ArticleInsightsChain<TaskId> extends PrivateChain<
               minimumImportanceScoreRules:
                 this.provider.determineScoreOptions.minimumImportanceScoreRules,
               dateService: this.dateService,
+              promptBuilder: this.promptProvider?.determineImportance,
             });
 
             const { result: importanceScore } =

--- a/src/generate-newsletter/chains/content-generate.chain.ts
+++ b/src/generate-newsletter/chains/content-generate.chain.ts
@@ -7,6 +7,7 @@ import { pick } from 'es-toolkit';
 import { JSDOM } from 'jsdom';
 import safeMarkdown2Html from 'safe-markdown2html';
 
+import type { PromptProvider } from '~/generate-newsletter/models/prompt-provider';
 import { LoggingExecutor } from '~/logging/logging-executor';
 import type { DateService } from '~/models/interfaces';
 import type { Newsletter } from '~/models/newsletter';
@@ -24,6 +25,7 @@ async function inlineCss(html: string): Promise<string> {
 
 type Config<TaskId> = ChainConfig<TaskId, ContentGenerateProvider> & {
   dateService: DateService;
+  promptProvider?: PromptProvider['contentGenerate'];
 };
 
 export default class ContentGenerateChain<TaskId> extends Chain<
@@ -34,11 +36,13 @@ export default class ContentGenerateChain<TaskId> extends Chain<
   private readonly minimumArticleCountForIssue: number;
   private readonly priorityArticleScoreThreshold: number;
   private readonly htmlTemplate: RequiredHtmlTemplate;
+  private readonly promptProvider?: PromptProvider['contentGenerate'];
 
   constructor(config: Config<TaskId>) {
     super(config);
 
     this.dateService = config.dateService;
+    this.promptProvider = config.promptProvider;
     this.minimumArticleCountForIssue =
       config.provider.publicationCriteria?.minimumArticleCountForIssue ?? 5;
     this.priorityArticleScoreThreshold =
@@ -158,6 +162,7 @@ export default class ContentGenerateChain<TaskId> extends Chain<
           subscribePageUrl: this.provider.subscribePageUrl,
           newsletterBrandName: this.provider.newsletterBrandName,
           dateService: this.dateService,
+          promptBuilder: this.promptProvider?.generateNewsletter,
         });
 
         const { result } = await generateNewsletter.execute();

--- a/src/generate-newsletter/llm-queries/analyze-images.llm.test.ts
+++ b/src/generate-newsletter/llm-queries/analyze-images.llm.test.ts
@@ -156,6 +156,48 @@ describe('AnalyzeImages', () => {
     ]);
   });
 
+  test('uses custom promptBuilder for system and user prompts', async () => {
+    const detailContent = '![a](https://img.com/a.png)\nSome text';
+    const customSystem = vi.fn().mockReturnValue('custom system');
+    const customUser = vi.fn().mockReturnValue('custom user text');
+
+    const query = buildQuery({
+      targetArticle: {
+        title: 'Custom prompt test',
+        detailContent,
+        hasAttachedImage: true,
+      },
+      promptBuilder: { system: customSystem, user: customUser },
+    });
+
+    const stubUsage = { inputTokens: 10, outputTokens: 5, totalTokens: 15 };
+    vi.mocked(generateText).mockResolvedValue({
+      output: { imageContext: 'result' },
+      usage: stubUsage,
+    } as any);
+
+    await query.execute();
+
+    const callArg = vi.mocked(generateText).mock.calls[0][0] as any;
+    expect(callArg.system).toBe('custom system');
+
+    const textPart = callArg.messages[0].content[0];
+    expect(textPart.text).toBe('custom user text');
+
+    expect(customSystem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expertFields: ['AI'],
+        outputLanguage: 'Korean',
+      }),
+    );
+    expect(customUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expertFields: ['AI'],
+        outputLanguage: 'Korean',
+      }),
+    );
+  });
+
   test('filters out invalid URLs and empty URLs from image extraction', async () => {
     const detailContent = [
       '![valid](https://ok.com/img.png)',

--- a/src/generate-newsletter/llm-queries/analyze-images.llm.ts
+++ b/src/generate-newsletter/llm-queries/analyze-images.llm.ts
@@ -1,4 +1,8 @@
 import type { UnscoredArticle } from '../models/article';
+import type {
+  AnalyzeImagesPromptContext,
+  PromptBuilder,
+} from '../models/prompt-provider';
 
 import { z } from 'zod';
 
@@ -8,6 +12,10 @@ import {
   type LLMQueryConfig,
   type LLMQueryExecuteResult,
 } from './llm-query';
+
+type Config<TaskId> = LLMQueryConfig<TaskId> & {
+  promptBuilder?: PromptBuilder<AnalyzeImagesPromptContext>;
+};
 
 type ReturnType = string | null;
 
@@ -37,8 +45,11 @@ export default class AnalyzeImages<TaskId> extends LLMQuery<
       ),
   });
 
-  constructor(config: LLMQueryConfig<TaskId>) {
+  private readonly promptBuilder?: PromptBuilder<AnalyzeImagesPromptContext>;
+
+  constructor(config: Config<TaskId>) {
     super(config);
+    this.promptBuilder = config.promptBuilder;
   }
 
   public async execute(): Promise<LLMQueryExecuteResult<ReturnType>> {
@@ -69,7 +80,19 @@ export default class AnalyzeImages<TaskId> extends LLMQuery<
     return { result: output.imageContext, usage };
   }
 
+  private get promptContext(): AnalyzeImagesPromptContext {
+    return {
+      expertFields: this.expertFields,
+      outputLanguage: this.options.content.outputLanguage,
+      targetArticle: this.targetArticle,
+    };
+  }
+
   private get systemPrompt(): string {
+    if (this.promptBuilder?.system) {
+      return this.promptBuilder.system(this.promptContext);
+    }
+
     return `# Image Analysis Expert System
 
 ## Identity & Expertise
@@ -149,6 +172,13 @@ You are a specialized image analysis expert in: ${this.expertFields.join(', ')}
   }
 
   private get textMessage() {
+    if (this.promptBuilder?.user) {
+      return {
+        type: 'text' as const,
+        text: this.promptBuilder.user(this.promptContext),
+      };
+    }
+
     return {
       type: 'text' as const,
       text: `## Analysis Task

--- a/src/generate-newsletter/llm-queries/classify-tags.llm.test.ts
+++ b/src/generate-newsletter/llm-queries/classify-tags.llm.test.ts
@@ -72,4 +72,112 @@ describe('ClassifyTags', () => {
     expect(callArg.prompt).toContain('**Article Information**');
     expect(callArg.prompt).toContain(JSON.stringify(existTags, null, 2));
   });
+
+  test('uses custom promptBuilder when provided', async () => {
+    const model: any = { name: 'fake-model' };
+    const logger: any = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+    const loggingExecutor: any = {
+      executeWithLogging: vi.fn(async (_taskId: any, fn: any) => fn()),
+    };
+    const options: any = {
+      content: { outputLanguage: 'Korean', expertField: 'AI' },
+      llm: { maxRetries: 3 },
+    };
+    const targetArticle: any = {
+      title: 'Test Article',
+      detailContent: 'Test content',
+    };
+
+    const customSystem = vi.fn().mockReturnValue('custom system prompt');
+    const customUser = vi.fn().mockReturnValue('custom user prompt');
+
+    const query = new ClassifyTags({
+      model,
+      logger,
+      taskId: 'task-1',
+      targetArticle,
+      options,
+      loggingExecutor,
+      promptBuilder: { system: customSystem, user: customUser },
+    });
+
+    const stubUsage = { inputTokens: 5, outputTokens: 10, totalTokens: 15 };
+    vi.mocked(generateText).mockResolvedValue({
+      output: { tag1: 'a', tag2: 'b', tag3: 'c' },
+      usage: stubUsage,
+    } as any);
+
+    await query.execute({ existTags: ['existing'] });
+
+    const callArg = vi.mocked(generateText).mock.calls[0][0] as any;
+    expect(callArg.system).toBe('custom system prompt');
+    expect(callArg.prompt).toBe('custom user prompt');
+
+    expect(customSystem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expertFields: ['AI'],
+        outputLanguage: 'Korean',
+        targetArticle,
+        existTags: ['existing'],
+      }),
+    );
+    expect(customUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expertFields: ['AI'],
+        outputLanguage: 'Korean',
+        targetArticle,
+        existTags: ['existing'],
+      }),
+    );
+  });
+
+  test('uses default prompt when only system promptBuilder is provided', async () => {
+    const model: any = { name: 'fake-model' };
+    const logger: any = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+    const loggingExecutor: any = {
+      executeWithLogging: vi.fn(async (_taskId: any, fn: any) => fn()),
+    };
+    const options: any = {
+      content: { outputLanguage: 'Korean', expertField: 'AI' },
+      llm: { maxRetries: 3 },
+    };
+    const targetArticle: any = {
+      title: 'Test',
+      detailContent: 'Content',
+    };
+
+    const customSystem = vi.fn().mockReturnValue('custom system only');
+
+    const query = new ClassifyTags({
+      model,
+      logger,
+      taskId: 'task-1',
+      targetArticle,
+      options,
+      loggingExecutor,
+      promptBuilder: { system: customSystem },
+    });
+
+    const stubUsage = { inputTokens: 5, outputTokens: 10, totalTokens: 15 };
+    vi.mocked(generateText).mockResolvedValue({
+      output: { tag1: 'a', tag2: 'b', tag3: 'c' },
+      usage: stubUsage,
+    } as any);
+
+    await query.execute({ existTags: [] });
+
+    const callArg = vi.mocked(generateText).mock.calls[0][0] as any;
+    expect(callArg.system).toBe('custom system only');
+    expect(callArg.prompt).toContain('**Task**');
+  });
 });

--- a/src/generate-newsletter/llm-queries/classify-tags.llm.ts
+++ b/src/generate-newsletter/llm-queries/classify-tags.llm.ts
@@ -1,9 +1,17 @@
 import type { UnscoredArticle } from '../models/article';
+import type {
+  ClassifyTagsPromptContext,
+  PromptBuilder,
+} from '../models/prompt-provider';
 
 import { z } from 'zod';
 
 import { generateObjectByLLM } from './generate-object-by-llm';
 import { LLMQuery, type LLMQueryConfig } from './llm-query';
+
+type Config<TaskId> = LLMQueryConfig<TaskId> & {
+  promptBuilder?: PromptBuilder<ClassifyTagsPromptContext>;
+};
 
 type Params = {
   existTags: string[];
@@ -22,10 +30,12 @@ export default class ClassifyTags<TaskId> extends LLMQuery<
     tag3: z.string(),
   });
 
+  private readonly promptBuilder?: PromptBuilder<ClassifyTagsPromptContext>;
   private existTags: string[] = [];
 
-  constructor(config: LLMQueryConfig<TaskId>) {
+  constructor(config: Config<TaskId>) {
     super(config);
+    this.promptBuilder = config.promptBuilder;
   }
 
   public async execute({ existTags }: Params) {
@@ -42,7 +52,20 @@ export default class ClassifyTags<TaskId> extends LLMQuery<
     return { result: output, usage };
   }
 
+  private get promptContext(): ClassifyTagsPromptContext {
+    return {
+      expertFields: this.expertFields,
+      outputLanguage: this.options.content.outputLanguage,
+      targetArticle: this.targetArticle,
+      existTags: this.existTags,
+    };
+  }
+
   private get systemPrompt(): string {
+    if (this.promptBuilder?.system) {
+      return this.promptBuilder.system(this.promptContext);
+    }
+
     return `You are an AI specializing in analyzing and categorizing articles for professionals in ${this.expertFields.join(', ')}.
 
 ## Core Responsibility
@@ -56,7 +79,7 @@ All classifications must be written in ${this.options.content.outputLanguage}.
 2. **New Tag Criteria**: Create new classifications only when:
    - Best existing match scores below 80% compatibility
    - New tag demonstrates versatility across 10+ similar articles
-3. **Naming Standards**: 
+3. **Naming Standards**:
    - Length: 3-15 characters
    - Style: Clear, intuitive ${this.options.content.outputLanguage} terms
    - Balance industry precision with general reader comprehension
@@ -71,6 +94,10 @@ Prioritize in order:
   }
 
   private get userPrompt(): string {
+    if (this.promptBuilder?.user) {
+      return this.promptBuilder.user(this.promptContext);
+    }
+
     return `**Task**: Classify this article with 3 optimal detailed tags.
 
 **Article Information**

--- a/src/generate-newsletter/llm-queries/determine-article-importance.llm.test.ts
+++ b/src/generate-newsletter/llm-queries/determine-article-importance.llm.test.ts
@@ -247,6 +247,72 @@ describe('DetermineArticleImportance', () => {
   });
 });
 
+describe('DetermineArticleImportance - promptBuilder', () => {
+  const date = '2024-01-02T10:00:00.000Z';
+
+  test('uses custom promptBuilder when provided', async () => {
+    const model: any = { name: 'fake-model' };
+    const logger: any = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+    const loggingExecutor: any = {
+      executeWithLogging: vi.fn(async (_taskId: any, fn: any) => fn()),
+    };
+    const options: any = {
+      content: { outputLanguage: 'Korean', expertField: 'AI' },
+      llm: { maxRetries: 2 },
+    };
+    const targetArticle: any = {
+      targetUrl: 'https://example.com/a',
+      title: 'Test',
+      detailContent: 'Content',
+      tag1: 'T1',
+      tag2: 'T2',
+      tag3: 'T3',
+    };
+
+    const customSystem = vi.fn().mockReturnValue('custom system');
+    const customUser = vi.fn().mockReturnValue('custom user');
+
+    const query = new DetermineArticleImportance({
+      model,
+      logger,
+      taskId: 'task-prompt',
+      targetArticle,
+      options,
+      loggingExecutor,
+      dateService: {
+        getPublicationISODateString: () => date,
+        getPublicationDisplayDateString: () => date,
+      },
+      promptBuilder: { system: customSystem, user: customUser },
+    });
+
+    vi.mocked(generateText).mockResolvedValue({
+      output: { importanceScore: 5 },
+      usage: {},
+    } as any);
+
+    await query.execute();
+
+    const callArg = vi.mocked(generateText).mock.calls[0][0] as any;
+    expect(callArg.system).toBe('custom system');
+    expect(callArg.prompt).toBe('custom user');
+
+    expect(customSystem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expertFields: ['AI'],
+        targetArticle,
+        minimumImportanceScoreRules: [],
+      }),
+    );
+    expect(customSystem.mock.calls[0][0].dateService).toBeDefined();
+  });
+});
+
 describe('DetermineArticleImportance - fallbacks', () => {
   test('uses fallback values when title/content/tags are missing', async () => {
     const model: any = { name: 'fake-model-3' };

--- a/src/generate-newsletter/llm-queries/determine-article-importance.llm.ts
+++ b/src/generate-newsletter/llm-queries/determine-article-importance.llm.ts
@@ -1,5 +1,9 @@
 import type { UnscoredArticle } from '../models/article';
 import type { MinimumImportanceScoreRule } from '../models/interfaces';
+import type {
+  DetermineImportancePromptContext,
+  PromptBuilder,
+} from '../models/prompt-provider';
 
 import { z } from 'zod';
 
@@ -11,6 +15,7 @@ import { LLMQuery, type LLMQueryConfig } from './llm-query';
 type Config<TaskId> = LLMQueryConfig<TaskId> & {
   minimumImportanceScoreRules?: MinimumImportanceScoreRule[];
   dateService: DateService;
+  promptBuilder?: PromptBuilder<DetermineImportancePromptContext>;
 };
 
 export default class DetermineArticleImportance<TaskId> extends LLMQuery<
@@ -29,12 +34,14 @@ export default class DetermineArticleImportance<TaskId> extends LLMQuery<
   });
 
   private readonly dateService: DateService;
+  private readonly promptBuilder?: PromptBuilder<DetermineImportancePromptContext>;
 
   constructor(config: Config<TaskId>) {
     super(config);
 
     this.minimumImportanceScoreRules = config.minimumImportanceScoreRules ?? [];
     this.dateService = config.dateService;
+    this.promptBuilder = config.promptBuilder;
   }
 
   public async execute() {
@@ -61,7 +68,20 @@ export default class DetermineArticleImportance<TaskId> extends LLMQuery<
     return this.minPoint > 1;
   }
 
-  private get systemPrompt() {
+  private get promptContext(): DetermineImportancePromptContext {
+    return {
+      expertFields: this.expertFields,
+      targetArticle: this.targetArticle,
+      dateService: this.dateService,
+      minimumImportanceScoreRules: this.minimumImportanceScoreRules,
+    };
+  }
+
+  private get systemPrompt(): string {
+    if (this.promptBuilder?.system) {
+      return this.promptBuilder.system(this.promptContext);
+    }
+
     return `You are an expert in importance evaluation in the field of ${this.expertFields.join(', ')}.
 
 Role:
@@ -100,7 +120,11 @@ Important Notes:
 - Be sensitive to core keywords, events, policies considered important in the field.`;
   }
 
-  private get userPrompt() {
+  private get userPrompt(): string {
+    if (this.promptBuilder?.user) {
+      return this.promptBuilder.user(this.promptContext);
+    }
+
     return `Please rate the importance of this article from ${this.minPoint} to 10.
 
 **Newsletter Publication Date:** ${this.dateService.getPublicationISODateString()}${

--- a/src/generate-newsletter/llm-queries/generate-newsletter.llm.test.ts
+++ b/src/generate-newsletter/llm-queries/generate-newsletter.llm.test.ts
@@ -513,6 +513,71 @@ describe('GenerateNewsletter.execute', () => {
     );
   });
 
+  test('uses custom promptBuilder when provided', async () => {
+    const customSystem = vi.fn().mockReturnValue('custom system prompt');
+    const customUser = vi.fn().mockReturnValue('custom user prompt');
+
+    mockObjectOnce({
+      title: longTitle,
+      content: 'Generated content',
+      isWrittenInOutputLanguage: true,
+      copyrightVerified: true,
+      factAccuracy: true,
+    });
+
+    const instance = new (GenerateNewsletter as any)(
+      buildConfig({
+        promptBuilder: { system: customSystem, user: customUser },
+      }),
+    );
+
+    await instance.execute();
+
+    const callArg = vi.mocked(generateText).mock.calls[0][0] as any;
+    expect(callArg.system).toBe('custom system prompt');
+    expect(callArg.prompt).toBe('custom user prompt');
+
+    expect(customSystem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expertFields: ['AI', 'Robotics'],
+        outputLanguage: 'English',
+        newsletterBrandName: 'TechPulse',
+        subscribePageUrl: 'https://example.com/subscribe',
+      }),
+    );
+    expect(customUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expertFields: ['AI', 'Robotics'],
+        targetArticles: expect.any(Array),
+      }),
+    );
+    expect(customSystem.mock.calls[0][0].dateService).toBeDefined();
+  });
+
+  test('uses default user prompt when only system promptBuilder is provided', async () => {
+    const customSystem = vi.fn().mockReturnValue('custom system only');
+
+    mockObjectOnce({
+      title: longTitle,
+      content: 'Content',
+      isWrittenInOutputLanguage: true,
+      copyrightVerified: true,
+      factAccuracy: true,
+    });
+
+    const instance = new (GenerateNewsletter as any)(
+      buildConfig({
+        promptBuilder: { system: customSystem },
+      }),
+    );
+
+    await instance.execute();
+
+    const callArg = vi.mocked(generateText).mock.calls[0][0] as any;
+    expect(callArg.system).toBe('custom system only');
+    expect(callArg.prompt).toContain('Below is the complete list');
+  });
+
   test('uses provided sampling/penalty options and omits subscribe link when not given', async () => {
     mockObjectOnce({
       title: longTitle,

--- a/src/generate-newsletter/llm-queries/generate-newsletter.llm.ts
+++ b/src/generate-newsletter/llm-queries/generate-newsletter.llm.ts
@@ -1,6 +1,10 @@
 import type { LanguageModelUsage } from 'ai';
 
 import type { ArticleForGenerateContent } from '../models/article';
+import type {
+  GenerateNewsletterPromptContext,
+  PromptBuilder,
+} from '../models/prompt-provider';
 
 import { pick } from 'es-toolkit';
 import { z } from 'zod';
@@ -27,6 +31,7 @@ type Config<TaskId> = BaseLLMQueryConfig<TaskId> & {
   dateService: DateService;
   subscribePageUrl?: UrlString;
   newsletterBrandName: string;
+  promptBuilder?: PromptBuilder<GenerateNewsletterPromptContext>;
 };
 
 type ReturnType = Pick<Newsletter, 'title' | 'content'>;
@@ -46,6 +51,7 @@ export default class GenerateNewsletter<TaskId> extends BaseLLMQuery<
   private readonly dateService: DateService;
   private readonly subscribePageUrl?: UrlString;
   private readonly newsletterBrandName: string;
+  private readonly promptBuilder?: PromptBuilder<GenerateNewsletterPromptContext>;
 
   private readonly schema = z.object({
     title: z.string().max(70).min(20).describe('Title of the newsletter email'),
@@ -80,6 +86,7 @@ export default class GenerateNewsletter<TaskId> extends BaseLLMQuery<
     this.dateService = config.dateService;
     this.subscribePageUrl = config.subscribePageUrl;
     this.newsletterBrandName = config.newsletterBrandName;
+    this.promptBuilder = config.promptBuilder;
   }
 
   public async execute(): Promise<LLMQueryExecuteResult<ReturnType>> {
@@ -123,7 +130,24 @@ export default class GenerateNewsletter<TaskId> extends BaseLLMQuery<
     return { result: pick(output, ['title', 'content']), usage };
   }
 
+  private get promptContext(): GenerateNewsletterPromptContext {
+    return {
+      expertFields: this.expertFields,
+      outputLanguage: this.options.content.outputLanguage,
+      dateService: this.dateService,
+      targetArticles: this.targetArticles,
+      freeFormIntro: this.options.content.freeFormIntro,
+      titleContext: this.options.content.titleContext,
+      subscribePageUrl: this.subscribePageUrl,
+      newsletterBrandName: this.newsletterBrandName,
+    };
+  }
+
   private get systemPrompt(): string {
+    if (this.promptBuilder?.system) {
+      return this.promptBuilder.system(this.promptContext);
+    }
+
     return `You are a newsletter production expert for "${this.newsletterBrandName}" who analyzes and delivers trends in the fields of ${this.expertFields.join(', ')}. Your goal is to provide in-depth analysis that helps industry professionals easily understand complex information and make informed decisions.
 
 Important rule for displaying date ranges: When displaying date ranges, you must use a hyphen (-) instead of a tilde (~). For example, use 'June 1-2, 2025' instead of 'June 1~2, 2025'. The tilde (~) can be rendered as strikethrough in markdown.
@@ -258,6 +282,10 @@ Output Format & Requirements:
   }
 
   private get userPrompt(): string {
+    if (this.promptBuilder?.user) {
+      return this.promptBuilder.user(this.promptContext);
+    }
+
     return `Below is the complete list of newly collected ${this.expertFields.join(', ')} related news:
 
 ${this.targetArticles

--- a/src/generate-newsletter/models/interfaces.ts
+++ b/src/generate-newsletter/models/interfaces.ts
@@ -17,6 +17,7 @@ import type { UrlString } from '~/models/common';
 import type { EmailMessage } from '~/models/email';
 import type { AppLogger, DateService, EmailService } from '~/models/interfaces';
 import type { Newsletter } from '~/models/newsletter';
+import type { PromptProvider } from './prompt-provider';
 
 /**
  * Task module managed by the client for newsletter generation.
@@ -353,4 +354,10 @@ export type GenerateNewsletterConfig<TaskId> = {
    * Optional behavior/settings.
    */
   options?: GenerateNewsletterOptions;
+
+  /**
+   * Optional provider for customizing LLM prompts.
+   * When omitted, built-in default prompts are used.
+   */
+  promptProvider?: PromptProvider;
 };

--- a/src/generate-newsletter/models/interfaces.ts
+++ b/src/generate-newsletter/models/interfaces.ts
@@ -11,13 +11,13 @@ import type {
   ParsedTarget,
 } from './crawling';
 import type { ChainOptions, ContentOptions, LLMQueryOptions } from './options';
+import type { PromptProvider } from './prompt-provider';
 import type { HtmlTemplate } from './template';
 
 import type { UrlString } from '~/models/common';
 import type { EmailMessage } from '~/models/email';
 import type { AppLogger, DateService, EmailService } from '~/models/interfaces';
 import type { Newsletter } from '~/models/newsletter';
-import type { PromptProvider } from './prompt-provider';
 
 /**
  * Task module managed by the client for newsletter generation.

--- a/src/generate-newsletter/models/prompt-provider.ts
+++ b/src/generate-newsletter/models/prompt-provider.ts
@@ -1,0 +1,80 @@
+import type { ArticleForGenerateContent } from './article';
+import type { UnscoredArticle } from './article';
+import type { MinimumImportanceScoreRule } from './interfaces';
+
+import type { UrlString } from '~/models/common';
+import type { DateService } from '~/models/interfaces';
+
+/**
+ * A pair of optional prompt builder functions.
+ * The returned string **replaces** the built-in default prompt entirely.
+ * If omitted, the default prompt is used.
+ */
+export type PromptBuilder<TContext> = {
+  system?: (context: TContext) => string;
+  user?: (context: TContext) => string;
+};
+
+// ─── Context types ───────────────────────────────────────────────
+
+export type ClassifyTagsPromptContext = {
+  expertFields: string[];
+  outputLanguage: string;
+  targetArticle: UnscoredArticle;
+  existTags: string[];
+};
+
+export type AnalyzeImagesPromptContext = {
+  expertFields: string[];
+  outputLanguage: string;
+  targetArticle: UnscoredArticle;
+};
+
+export type DetermineImportancePromptContext = {
+  expertFields: string[];
+  targetArticle: UnscoredArticle;
+  dateService: DateService;
+  minimumImportanceScoreRules: MinimumImportanceScoreRule[];
+};
+
+export type GenerateNewsletterPromptContext = {
+  expertFields: string[];
+  outputLanguage: string;
+  dateService: DateService;
+  targetArticles: ArticleForGenerateContent[];
+  freeFormIntro?: boolean;
+  titleContext?: string;
+  subscribePageUrl?: UrlString;
+  newsletterBrandName: string;
+};
+
+// ─── Main interface ──────────────────────────────────────────────
+
+/**
+ * Optional provider for customizing LLM prompts.
+ * Grouped by pipeline stage. All fields are optional —
+ * omitted prompts fall back to built-in defaults.
+ *
+ * **Dependency note:** Analysis prompts (❶❷❸) produce data that flows
+ * into the content generation prompt (❹). Changing an analysis prompt
+ * may indirectly affect the final newsletter output.
+ */
+export interface PromptProvider {
+  /**
+   * Analysis stage prompts (❶ classifyTags → ❷ analyzeImages → ❸ determineImportance).
+   * Results feed into the content generation stage.
+   */
+  analysis?: {
+    classifyTags?: PromptBuilder<ClassifyTagsPromptContext>;
+    analyzeImages?: PromptBuilder<AnalyzeImagesPromptContext>;
+    determineImportance?: PromptBuilder<DetermineImportancePromptContext>;
+  };
+
+  /**
+   * Content generation stage prompt (❹ generateNewsletter).
+   * Produces the final newsletter title and body.
+   */
+  contentGenerate?: {
+    generateNewsletter?: PromptBuilder<GenerateNewsletterPromptContext>;
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export type * from './generate-newsletter/models/article';
 export type * from './generate-newsletter/models/interfaces';
+export type * from './generate-newsletter/models/prompt-provider';
 export type * from './models/newsletter';
 export type * from './generate-newsletter/models/crawling';
 export type * from './generate-newsletter/models/template';


### PR DESCRIPTION
Allow external packages to replace built-in LLM prompts via the new optional `promptProvider` field in GenerateNewsletterConfig.

- Define PromptProvider interface grouped by pipeline stage (analysis / contentGenerate)
- Support per-query prompt replacement for all 4 LLM queries: classifyTags, analyzeImages, determineImportance, generateNewsletter
- Each PromptBuilder receives a typed context object with relevant options so custom prompts can reference them as needed
- All fields are optional — omitted prompts fall back to defaults
- Export all new types from the public API surface (index.ts)

## Summary

Add a `PromptProvider` interface that allows external packages to inject and replace the hardcoded LLM prompts. Prompts are grouped by pipeline stage (`analysis` / `contentGenerate`), and each of the 4 LLM Queries can have its system/user prompt selectively replaced.

## Changes

- `src/generate-newsletter/models/prompt-provider.ts` (new) — Define `PromptProvider`, `PromptBuilder<TContext>`, and 4 context types
- `src/generate-newsletter/models/interfaces.ts` — Add optional `promptProvider?: PromptProvider` field to `GenerateNewsletterConfig`
- `src/generate-newsletter.ts` — Store `promptProvider` and pass it down to analysis/contentGenerate chains
- `src/generate-newsletter/chains/analysis.chain.ts` — Accept `promptProvider.analysis` and forward to ArticleInsightsChain
- `src/generate-newsletter/chains/article-insights.chain.ts` — Inject corresponding `promptBuilder` into each LLM Query
- `src/generate-newsletter/chains/content-generate.chain.ts` — Accept `promptProvider.contentGenerate` and inject into GenerateNewsletter LLM Query
- `src/generate-newsletter/llm-queries/*.llm.ts` (4 files) — Accept `promptBuilder`, replace default prompt when provided, add context getter
- `src/index.ts` — Export new types from public API surface
- Test files (4 files) — Add tests verifying prompt replacement behavior with promptBuilder

## Breaking Changes

- [x] None

## Checklist

- [x] I followed the Code of Conduct (see CODE_OF_CONDUCT.md)
- [x] I ran: `npm run format:check` `npm run lint` `npm run typecheck` `npm run build` `npm test`
- [x] Tests added/updated; coverage remains 100%
- [x] Docs/README updated if needed
- [x] No external side effects (network/file/process/time) in tests — use mocks

## Related Issues

Closes #